### PR TITLE
Fixing #JENKINS-12048

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -252,7 +252,11 @@ public class MercurialSCM extends SCM implements Serializable {
             
             ArgumentListBuilder logCmd = findHgExe(node, listener, false);
             logCmd.add("log", "--style", tmpFile.getRemote());
-            logCmd.add("--branch", getBranch());
+            // Note: In order to support older Mercurial Versions including the
+            // one used by Ubuntu 10.04 LTS, using the short option "-b"
+            // instead of "--branch" which was renamed from "--only-branch",
+            // see JENKINS-12048.
+            logCmd.add("-b", getBranch());
             logCmd.add("--no-merges");
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
In previous Mercurial versions like the one used in Ubuntu 10.04 LTS, the long
name of the "-b" switch for "hg log" was "--only-branch", while it now is
"--branch". Using the short name allows the plugin to work with both old and
new versions.

[Fixed Issue](https://issues.jenkins-ci.org/browse/JENKINS-12048)
