### PR TITLE
Implement requiresWorkspaceForPolling

### DIFF
--- a/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
@@ -493,7 +493,11 @@ public class MercurialSCMTest extends MercurialTestCase {
         // We lost the workspace
         b.getWorkspace().deleteRecursive();
         pr = pollSCMChanges(p);
-        assertPollingResult(PollingResult.Change.INCOMPARABLE, null, null, pr);
+        if (p.getScm().requiresWorkspaceForPolling()) {
+            assertPollingResult(PollingResult.Change.INCOMPARABLE, null, null, pr);
+        } else {
+            assertPollingResult(PollingResult.Change.NONE, cs2, cs2, pr);
+        }
         b = p.scheduleBuild2(0).get();
 
         // Multiple polls


### PR DESCRIPTION
When using caching, all poll operations can be performed on the central cache, so no workspace is necessary

This has the benefit that restarting Jenkins does not trigger all jobs on slaves to be scheduled, merely to get a workspace.
