### PR TITLE
Fix for JENKINS-12361

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -325,8 +325,9 @@ public class MercurialSCM extends SCM implements Serializable {
         Set<String> affecting = new HashSet<String>();
 
         for (String changedFile : changedFileNames) {
+            String unixChangedFile = changedFile.replace('\\', '/');
             for (String dependency : _modules) {
-                if (changedFile.startsWith(dependency)) {
+                if (unixChangedFile.startsWith(dependency)) {
                     affecting.add(changedFile);
                     break;
                 }

--- a/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
@@ -143,6 +143,25 @@ public class MercurialSCMTest extends MercurialTestCase {
         buildAndCheck(p, "dir1/f");
     }
 
+    @Bug(12361)
+    public void testPollingLimitedToModules3() throws Exception {
+        PollingResult pr;
+        FreeStyleProject p = createFreeStyleProject();
+        p.setScm(new MercurialSCM(hgInstallation, repo.getPath(), null, "dir1/f",
+                null, null, false));
+        hg(repo, "init");
+        touchAndCommit(repo, "starter");
+        pollSCMChanges(p);
+        buildAndCheck(p, "starter");
+        touchAndCommit(repo, "dir1/g");
+        pr = pollSCMChanges(p);
+        assertEquals(PollingResult.Change.INSIGNIFICANT, pr.change);
+        touchAndCommit(repo, "dir1/f");
+        pr = pollSCMChanges(p);
+        assertEquals(PollingResult.Change.SIGNIFICANT, pr.change);
+        buildAndCheck(p, "dir1/f");
+    }
+
     public void testParseStatus() throws Exception {
         assertEquals(new HashSet<String>(Arrays.asList("whatever", "added", "mo-re", "whatever-c", "initial", "more")), MercurialSCM.parseStatus(
                   "M whatever\n"


### PR DESCRIPTION
When parsing the result of 'hg status' to determine whether a significant change has occurred, convert all paths to unix format before comparing prefixes.

Fixes [JENKINS-12361](https://issues.jenkins-ci.org/browse/JENKINS-12361)
