### PR TITLE
Added interesting testcase for polling combined with merging to renamed modules

### DIFF
--- a/src/test/java/hudson/plugins/mercurial/MercurialTestCase.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialTestCase.java
@@ -65,10 +65,14 @@ public abstract class MercurialTestCase extends HudsonTestCase {
 
     protected void touchAndCommit(File repo, String... names) throws Exception {
         for (String name : names) {
-            FilePath toCreate = new FilePath(repo).child(name);
-            toCreate.getParent().mkdirs();
-            toCreate.touch(0);
-            hg(repo, "add", name);
+            FilePath toTouch = new FilePath(repo).child(name);
+            if (!toTouch.exists()) {
+                toTouch.getParent().mkdirs();
+                toTouch.touch(0);
+                hg(repo, "add", name);
+            } else {
+                toTouch.write(toTouch.readToString() + "extra line\n", "UTF-8");
+            }
         }
         hg(repo, "commit", "--message", "added " + Arrays.toString(names));
     }


### PR DESCRIPTION
Added testcase for merging changes to a renamed directory that happens to be the module configured for a Jenkins job

Before the polling was changed to use 'hg stat', this used to be problematic, but it works properly now that hg status is used.
Adding this testcase anyway as we were impacted by this quite heavily
