### PR TITLE
[JENKINS-12763] Reduce lock contention while updating caches

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/HgExe.java
+++ b/src/main/java/hudson/plugins/mercurial/HgExe.java
@@ -94,10 +94,6 @@ public class HgExe {
         return run("pull");
     }
 
-    public ProcStarter pull(String branch) {
-        return run("pull", "--branch", branch);
-    }
-
     public ProcStarter clone(String... args) {
         return l(seed().add("clone").add(args));
     }


### PR DESCRIPTION
Use different locks for controlling the updates of master and slave nodes caches.

Reduces lock contention and increases cache update performance; in particular in scenarios where multiple slaves are used for building jobs that build branches for several different repositories.

Regards,
David
