### PR TITLE
[FIXED JENKINS-15806] Check return code of hg pull.

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -506,7 +506,7 @@ public class MercurialSCM extends SCM implements Serializable {
         } 
         if (pullExitCode != 0) {
             listener.error("Failed to update");
-            //throw new AbortException("Failed to update");
+            throw new AbortException("Failed to update");
         }        
 
         int updateExitCode;


### PR DESCRIPTION
Hello, this fixed my issues with [issue 15806](https://issues.jenkins-ci.org/browse/JENKINS-15806). I did not manage to write a unit test, as the Jenkins test framework was a bit overwhelming. I would be happy to see a working unit test for this. The test i came up with (But which always fails, even in OK situation) :+1:

@Bug(15806)
public void testPullReturnCode() throws Exception
{
    File repo2 = createTmpDir();

```
hg(repo, "init");
touchAndCommit(repo, "init");
hg(repo, "tag", "init");

String s = repo.toString();
hg(repo2, "clone", repo.toString(), repo2.toString());

// delete repo 1 
repo.delete();


// do sample build where pull should fail
FreeStyleProject p = createFreeStyleProject();
MercurialSCM a = new MercurialSCM(hgInstallation(), repo2.getPath(), null, null,
        null, null, false);
p.setScm(a);

Future<FreeStyleBuild> b = p.scheduleBuild2(0);
while(!b.isDone())
{
    Thread.sleep(1000);
}
```

// unfortuneately this is not correct
assertEquals(Result.SUCCESS, b.get().getResult());

}
