### PR TITLE
Fix push notification when anonymous users lack read access

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.424</version>
+    <version>1.461</version>
   </parent>
 
   <artifactId>mercurial</artifactId>


### PR DESCRIPTION
Push notification (notifyCommit) does not work with enabled project based matrix authorization strategy. This is the same problem as [JENKINS-12022](https://issues.jenkins-ci.org/browse/JENKINS-12022) for git-plugin. The changes are mainly taken from the git-plugin.
