### PR TITLE
[FIXED JENKINS-17409] looselyMatches throws exception if second parameter (repository) is null

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
@@ -65,9 +65,6 @@ public class MercurialStatus extends AbstractModelObject implements UnprotectedR
     }
     
     static boolean looselyMatches(URI notifyUri, String repository) {
-        if (repository == null) {
-          return false;
-        }
         boolean result = false;
         try {
             URI repositoryUri = new URI(repository);


### PR DESCRIPTION
[JENKINS-17409](https://issues.jenkins-ci.org/browse/JENKINS-17409)
