### PR TITLE
Prevent relinking from blocking a checkout

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -508,7 +508,7 @@ public class MercurialSCM extends SCM implements Serializable {
         }
         if (build.getNumber() % 100 == 0) {
             PossiblyCachedRepo cachedSource = cachedSource(node, launcher, listener, true);
-            if (cachedSource != null) {
+            if (cachedSource != null && !cachedSource.isUseSharing()) {
                 // Periodically recreate hardlinks to the cache to save disk space.
                 hg.run("--config", "extensions.relink=", "relink", cachedSource.getRepoLocation()).pwd(repository).join(); // ignore failures
             }


### PR DESCRIPTION
When mercurial relinks two repositories, it needs to lock both data stores of the repositories. When you relink between two shared repositories, the two repositories are backed by the same store, so mercurial tries to double-lock the same store, which obviously times out.
