### PR TITLE
Expand 'subdir' to allow for environment variables/parameterization

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -181,7 +181,7 @@ public class MercurialSCM extends SCM implements Serializable {
         return branch == null ? "default" : env.expand(branch);
     }
 
-    public String getSubdir(EnvVars env) {
+    private String getSubdir(EnvVars env) {
         return env.expand( subdir );
     }
     


### PR DESCRIPTION
I have a build job that is used by lots of other jobs, the job is 'specialised' via the user of build parameters (this allows the child jobs to control what the parent job does). One aspect the children need to be able to control is the Mercurial subdir that the repository is cloned into. The getPollEnvironment function below is lifted from the git Jenkins plugin.
