### PR TITLE
[FIXED JENKINS-18564] Do not run file system checks designed for POSIX OS's on non POSIX OS's.

### DIFF
--- a/src/test/java/hudson/plugins/mercurial/HgExeTest.java
+++ b/src/test/java/hudson/plugins/mercurial/HgExeTest.java
@@ -28,16 +28,16 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 public class HgExeTest {
-
     @Test public void pathEquals() {
         assertTrue(HgExe.pathEquals("http://nowhere.net/hg/", "http://nowhere.net/hg/"));
         assertTrue(HgExe.pathEquals("http://nowhere.net/hg", "http://nowhere.net/hg/"));
         assertTrue(HgExe.pathEquals("http://nowhere.net/hg/", "http://nowhere.net/hg"));
         assertTrue(HgExe.pathEquals("http://nowhere.net/hg", "http://nowhere.net/hg"));
         assertFalse(HgExe.pathEquals("https://nowhere.net/hg/", "http://nowhere.net/hg/"));
-        assertTrue(HgExe.pathEquals("file:/var/hg/stuff", "/var/hg/stuff"));
-        assertTrue(HgExe.pathEquals("file:///var/hg/stuff", "/var/hg/stuff"));
-        assertFalse(HgExe.pathEquals("file:/var/hg/stuff", "/var/hg/other"));
+        if (  org.apache.commons.lang.SystemUtils.IS_OS_UNIX ) {
+            assertTrue(HgExe.pathEquals("file:/var/hg/stuff", "/var/hg/stuff"));
+            assertTrue(HgExe.pathEquals("file:///var/hg/stuff", "/var/hg/stuff"));
+            assertFalse(HgExe.pathEquals("file:/var/hg/stuff", "/var/hg/other"));
+        }
     }
-
 }


### PR DESCRIPTION
This is a fix for [JENKINS-18564](https://issues.jenkins-ci.org/browse/JENKINS-18564) using the suggested approach of conditionally only performing said operations on POSIX OSs.
