### PR TITLE
[FIXED JENKINS-15829] Don't recreate workspace when using Repository Sharing

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -484,15 +484,18 @@ public class MercurialSCM extends SCM implements Serializable {
             boolean jobShouldUseSharing, AbstractBuild<?,?> build,
             Launcher launcher, BuildListener listener)
                 throws IOException, InterruptedException {
-        if (!new FilePath(repo, ".hg/hgrc").exists()) {
-            return false;
-        }
 
         boolean jobUsesSharing = new FilePath(repo, ".hg/sharedpath").exists();
         if (jobShouldUseSharing != jobUsesSharing) {
             return false;
+        } else if(jobUsesSharing) {
+            return true;
         }
         
+        if (!new FilePath(repo, ".hg/hgrc").exists()) {
+            return false;
+        }
+
         HgExe hg = new HgExe(findInstallation(getInstallation()), getCredentials(build.getProject()), launcher, build.getBuiltOn(), listener, build.getEnvironment(listener));
         try {
         String upstream = hg.config(repo, "paths.default");


### PR DESCRIPTION
When using Repository Sharing, the working copy is always recloned (from the slave cache), which can take a long time on large repos.

This fixes the logic used to detect whether a workspace copy can be reused to support Repository Sharing.

[JENKINS-15829](https://issues.jenkins-ci.org/browse/JENKINS-15829)
