### PR TITLE
Add an option to use user/system hgrc files

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/HgExe.java
+++ b/src/main/java/hudson/plugins/mercurial/HgExe.java
@@ -151,7 +151,9 @@ public class HgExe {
         }
         this.node = node;
         this.env = env;
-        env.put("HGPLAIN", "true");
+        if (inst == null || !inst.isUseHgrc()) {
+          env.put("HGPLAIN", "true");
+        }
         this.launcher = launcher;
         this.listener = listener;
         this.capability = Capability.get(this);

--- a/src/main/java/hudson/plugins/mercurial/MercurialInstallation.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialInstallation.java
@@ -61,16 +61,18 @@ public class MercurialInstallation extends ToolInstallation implements
     private boolean debug;
     private boolean useCaches;
     private boolean useSharing;
+    private boolean useHgrc;
 
     @DataBoundConstructor
     public MercurialInstallation(String name, String home, String executable,
             boolean debug, boolean useCaches,
-            boolean useSharing, List<? extends ToolProperty<?>> properties) {
+            boolean useSharing, boolean useHgrc, List<? extends ToolProperty<?>> properties) {
         super(name, home, properties);
         this.executable = Util.fixEmpty(executable);
         this.debug = debug;
         this.useCaches = useCaches || useSharing;
         this.useSharing = useSharing;
+        this.useHgrc = useHgrc;
     }
 
     public String getExecutable() {
@@ -93,6 +95,10 @@ public class MercurialInstallation extends ToolInstallation implements
         return useSharing;
     }
 
+    public boolean isUseHgrc() {
+        return useHgrc;
+    }
+
     public static MercurialInstallation[] allInstallations() {
         return Hudson.getInstance().getDescriptorByType(DescriptorImpl.class)
                 .getInstallations();
@@ -101,14 +107,14 @@ public class MercurialInstallation extends ToolInstallation implements
     public MercurialInstallation forNode(Node node, TaskListener log)
             throws IOException, InterruptedException {
         return new MercurialInstallation(getName(), translateFor(node, log),
-                executable, debug, useCaches, useSharing,
+                executable, debug, useCaches, useSharing, useHgrc,
                 getProperties().toList());
     }
 
     public MercurialInstallation forEnvironment(EnvVars environment) {
         return new MercurialInstallation(getName(),
                 environment.expand(getHome()), executable,
-                debug, useCaches, useSharing, getProperties().toList());
+                debug, useCaches, useSharing, useHgrc, getProperties().toList());
     }
 
     @Extension

--- a/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
@@ -14,6 +14,9 @@
   <f:entry field="useSharing" title="${%Use Repository Sharing}">
     <f:checkbox/>
   </f:entry>
+  <f:entry field="useHgrc" title="${%Use hgrc Configuration}">
+    <f:checkbox/>
+  </f:entry>
   <f:entry field="debug" title="${%Debug Flag}">
     <f:checkbox/>
   </f:entry>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/help-useHgrc.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/help-useHgrc.html
@@ -1,0 +1,5 @@
+<div>
+  When checked, user and system hgrc files will be used.  Normally all user
+  and system configuration files are ignored.  Custom configuration can interfere
+  with the Mercurial plugin.  Use this option with caution.
+</div>

--- a/src/test/java/hudson/plugins/mercurial/CachingSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/CachingSCMTest.java
@@ -15,7 +15,7 @@ public class CachingSCMTest extends SCMTestBase {
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(CACHING_INSTALLATION, "",
-                                "hg", false, true, false, Collections
+                                "hg", false, true, false, false, Collections
                                         .<ToolProperty<?>> emptyList()));
         MercurialSCM.CACHE_LOCAL_REPOS = true;
     }

--- a/src/test/java/hudson/plugins/mercurial/DebugFlagTest.java
+++ b/src/test/java/hudson/plugins/mercurial/DebugFlagTest.java
@@ -15,7 +15,7 @@ public class DebugFlagTest extends SCMTestBase {
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(DEBUG_INSTALLATION, "", "hg",
-                                true, false, false, Collections
+                                true, false, false, false, Collections
                                         .<ToolProperty<?>> emptyList()));
     }
 

--- a/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
+++ b/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
@@ -45,7 +45,7 @@ import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 
 public class HgExeFunctionalTest {
@@ -63,7 +63,7 @@ public class HgExeFunctionalTest {
     public void setUp() throws Exception {
         this.mercurialInstallation = new MercurialInstallation(
                 INSTALLATION, "",
-                "hg", false, true, false, Collections
+                "hg", false, true, false, false, Collections
                 .<ToolProperty<?>> emptyList());
         this.listener = new StreamTaskListener(System.out, Charset.defaultCharset());
         this.launcher = j.jenkins.createLauncher(listener);
@@ -110,6 +110,27 @@ public class HgExeFunctionalTest {
                 "hg", "--config", "******").toString(),
                 b.toString());
         hgexe.close();
+    }
+
+    @Test public void withoutUseHgrc() throws Exception {
+        HgExe hgexe = new HgExe(
+                this.mercurialInstallation, null,
+                this.launcher, j.jenkins,
+                this.listener, this.vars);
+        assertTrue(this.vars.containsKey("HGPLAIN"));
+    }
+
+    @Test public void withUseHgrc() throws Exception {
+        MercurialInstallation inst = new MercurialInstallation(
+                INSTALLATION, "",
+                "hg", false, false, false, true, Collections
+                .<ToolProperty<?>> emptyList());
+
+        HgExe hgexe = new HgExe(
+                inst, null,
+                this.launcher, j.jenkins,
+                this.listener, this.vars);
+        assertFalse(this.vars.containsKey("HGPLAIN"));
     }
 
 }

--- a/src/test/java/hudson/plugins/mercurial/SharingSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/SharingSCMTest.java
@@ -15,7 +15,7 @@ public class SharingSCMTest extends SCMTestBase {
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(SHARING_INSTALLATION, "",
-                                "hg", false, true, true, Collections
+                                "hg", false, true, true, false, Collections
                                         .<ToolProperty<?>> emptyList()));
         MercurialSCM.CACHE_LOCAL_REPOS = true;
     }

--- a/src/test/java/hudson/plugins/mercurial/SwitchingSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/SwitchingSCMTest.java
@@ -30,13 +30,13 @@ public class SwitchingSCMTest {
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(cachingInstallation, "",
-                                "hg", false, true, false, Collections
+                                "hg", false, true, false, false, Collections
                                         .<ToolProperty<?>> emptyList()));
         Hudson.getInstance()
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(sharingInstallation, "",
-                                "hg", false, true, true, Collections
+                                "hg", false, true, true, false, Collections
                                         .<ToolProperty<?>> emptyList()));
 
         MercurialSCM.CACHE_LOCAL_REPOS = true;


### PR DESCRIPTION
By default, the plugin ignores user and system .hgrc files (e.g. `~/.hgrc`, `/etc/hgrc`, `%USERPROFILE%\Mercurial.ini`, etc.) by setting the `HGPLAIN` environment variable.

Occasionally, a user may want to use `/home/jenkins/.hgrc` to configure something the plugin doesn't have an explicit option for.  For example, I use it to remove compression from bundles when using Repository Caching as bzip2 compression is very slow.

This gives the user an option to use user and system .hgrc files at their own risk.  This is off by default and I added a caution message to the help file.

What do you think?
