### PR TITLE
[FIXED JENKINS-16654] Add option to disable changelog calculation

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialInstallation.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialInstallation.java
@@ -61,16 +61,26 @@ public class MercurialInstallation extends ToolInstallation implements
     private boolean debug;
     private boolean useCaches;
     private boolean useSharing;
+    private boolean disableChangeLog;
+
+    @Deprecated
+    public MercurialInstallation(String name, String home, String executable,
+            boolean debug, boolean useCaches,
+            boolean useSharing, List<? extends ToolProperty<?>> properties) {
+        this(name, home, executable, debug, useCaches, useSharing, false, properties);
+    }
 
     @DataBoundConstructor
     public MercurialInstallation(String name, String home, String executable,
             boolean debug, boolean useCaches,
-            boolean useSharing, List<? extends ToolProperty<?>> properties) {
+            boolean useSharing, boolean disableChangeLog,
+            List<? extends ToolProperty<?>> properties) {
         super(name, home, properties);
         this.executable = Util.fixEmpty(executable);
         this.debug = debug;
         this.useCaches = useCaches || useSharing;
         this.useSharing = useSharing;
+        this.disableChangeLog = disableChangeLog;
     }
 
     public String getExecutable() {
@@ -93,6 +103,10 @@ public class MercurialInstallation extends ToolInstallation implements
         return useSharing;
     }
 
+    public boolean isDisableChangeLog() {
+        return disableChangeLog;
+    }
+
     public static MercurialInstallation[] allInstallations() {
         return Hudson.getInstance().getDescriptorByType(DescriptorImpl.class)
                 .getInstallations();
@@ -101,14 +115,14 @@ public class MercurialInstallation extends ToolInstallation implements
     public MercurialInstallation forNode(Node node, TaskListener log)
             throws IOException, InterruptedException {
         return new MercurialInstallation(getName(), translateFor(node, log),
-                executable, debug, useCaches, useSharing,
+                executable, debug, useCaches, useSharing, disableChangeLog,
                 getProperties().toList());
     }
 
     public MercurialInstallation forEnvironment(EnvVars environment) {
         return new MercurialInstallation(getName(),
                 environment.expand(getHome()), executable,
-                debug, useCaches, useSharing, getProperties().toList());
+                debug, useCaches, useSharing, disableChangeLog, getProperties().toList());
     }
 
     @Extension

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -516,6 +516,12 @@ public class MercurialSCM extends SCM implements Serializable {
     }
 
     private void determineChanges(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener, File changelogFile, FilePath repository, String revToBuild) throws IOException, InterruptedException {
+        MercurialInstallation inst = findInstallation(getInstallation());
+        if (inst != null && inst.isDisableChangeLog()) {
+            createEmptyChangeLog(changelogFile, listener, "changelog");
+            return;
+        }
+
         AbstractBuild<?, ?> previousBuild = build.getPreviousBuild();
         MercurialTagAction prevTag = previousBuild != null ? findTag(previousBuild) : null;
         if (prevTag == null) {
@@ -524,7 +530,6 @@ public class MercurialSCM extends SCM implements Serializable {
             return;
         }
         EnvVars env = build.getEnvironment(listener);
-        MercurialInstallation inst = findInstallation(getInstallation());
         StandardUsernameCredentials credentials = getCredentials(build.getProject());
         HgExe hg = new HgExe(inst, credentials, launcher, build.getBuiltOn(), listener, env);
         try {

--- a/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
@@ -14,6 +14,9 @@
   <f:entry field="useSharing" title="${%Use Repository Sharing}">
     <f:checkbox/>
   </f:entry>
+  <f:entry field="disableChangeLog" title="${%Disable Changelog}">
+    <f:checkbox/>
+  </f:entry>
   <f:entry field="debug" title="${%Debug Flag}">
     <f:checkbox/>
   </f:entry>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/help-disableChangeLog.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/help-disableChangeLog.html
@@ -1,0 +1,5 @@
+<div>
+  When checked, Hudson will not calculate the Mercurial changelog for each build.
+  Disabling the changelog can decrease the amount of time needed to update a
+  very large repository.
+</div>

--- a/src/test/java/hudson/plugins/mercurial/CachingSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/CachingSCMTest.java
@@ -15,7 +15,7 @@ public class CachingSCMTest extends SCMTestBase {
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(CACHING_INSTALLATION, "",
-                                "hg", false, true, false, Collections
+                                "hg", false, true, false, false, Collections
                                         .<ToolProperty<?>> emptyList()));
         MercurialSCM.CACHE_LOCAL_REPOS = true;
     }

--- a/src/test/java/hudson/plugins/mercurial/DebugFlagTest.java
+++ b/src/test/java/hudson/plugins/mercurial/DebugFlagTest.java
@@ -15,7 +15,7 @@ public class DebugFlagTest extends SCMTestBase {
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(DEBUG_INSTALLATION, "", "hg",
-                                true, false, false, Collections
+                                true, false, false, false, Collections
                                         .<ToolProperty<?>> emptyList()));
     }
 

--- a/src/test/java/hudson/plugins/mercurial/DisableChangeLogTest.java
+++ b/src/test/java/hudson/plugins/mercurial/DisableChangeLogTest.java
@@ -1,0 +1,52 @@
+package hudson.plugins.mercurial;
+
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+import hudson.tools.ToolProperty;
+
+import java.io.File;
+import java.util.Collections;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class DisableChangeLogTest {
+    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule public MercurialRule m = new MercurialRule(j);
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+    private File repo;
+
+    private static final String DISABLE_CHANGELOG_INSTALLATION = "changelog";
+
+    @Before public void setUp() throws Exception {
+        repo = tmp.getRoot();
+        j.jenkins
+                .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
+                .setInstallations(
+                        new MercurialInstallation(DISABLE_CHANGELOG_INSTALLATION, "", "hg",
+                                true, false, false, true, Collections
+                                        .<ToolProperty<?>> emptyList()));
+    }
+
+    protected String hgInstallation() {
+        return DISABLE_CHANGELOG_INSTALLATION;
+    }
+
+    @Test public void changelogIsDisabled() throws Exception {
+        AbstractBuild<?, ?> b;
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(), null, null,
+                null, null, false));
+        m.hg(repo, "init");
+        m.touchAndCommit(repo, "dir1/f1");
+        b = p.scheduleBuild2(0).get();
+        assertTrue(b.getChangeSet().isEmptySet());
+        m.touchAndCommit(repo, "dir2/f1");
+        b = p.scheduleBuild2(0).get();
+        assertTrue(b.getChangeSet().isEmptySet());
+    }
+}

--- a/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
+++ b/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
@@ -63,7 +63,7 @@ public class HgExeFunctionalTest {
     public void setUp() throws Exception {
         this.mercurialInstallation = new MercurialInstallation(
                 INSTALLATION, "",
-                "hg", false, true, false, Collections
+                "hg", false, true, false, false, Collections
                 .<ToolProperty<?>> emptyList());
         this.listener = new StreamTaskListener(System.out, Charset.defaultCharset());
         this.launcher = j.jenkins.createLauncher(listener);

--- a/src/test/java/hudson/plugins/mercurial/SharingSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/SharingSCMTest.java
@@ -15,7 +15,7 @@ public class SharingSCMTest extends SCMTestBase {
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(SHARING_INSTALLATION, "",
-                                "hg", false, true, true, Collections
+                                "hg", false, true, true, false, Collections
                                         .<ToolProperty<?>> emptyList()));
         MercurialSCM.CACHE_LOCAL_REPOS = true;
     }

--- a/src/test/java/hudson/plugins/mercurial/SwitchingSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/SwitchingSCMTest.java
@@ -30,13 +30,13 @@ public class SwitchingSCMTest {
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(cachingInstallation, "",
-                                "hg", false, true, false, Collections
+                                "hg", false, true, false, false, Collections
                                         .<ToolProperty<?>> emptyList()));
         Hudson.getInstance()
                 .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
                 .setInstallations(
                         new MercurialInstallation(sharingInstallation, "",
-                                "hg", false, true, true, Collections
+                                "hg", false, true, true, false, Collections
                                         .<ToolProperty<?>> emptyList()));
 
         MercurialSCM.CACHE_LOCAL_REPOS = true;


### PR DESCRIPTION
In some very very large repositories, the changelog calculation can take quite a bit of time.  For users that do not care about seeing the changelog in Jenkins, this allows disabling the calculation, thus speeding up builds.

Our Jenkins infrastructure often needs to build older branches followed by newer branches and so on.  On top of that, our Mercurial repository is extremely large.  Calculating the changelog on this large repository can sometimes take 10-20 minutes.  Since we don't really care about displaying the changelog in Jenkins (it becomes meaningless given the large number of commits), it would be great to disable this and decrease build times.

[JENKINS-16654](https://issues.jenkins-ci.org/browse/JENKINS-16654)
