### PR TITLE
[FIXED JENKINS-16654] Add option to disable changelog calculation

### DIFF
--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCM/config.jelly
@@ -34,6 +34,9 @@
     <f:entry field="subdir" title="${%Subdirectory}">
       <f:textbox/>
     </f:entry>
+    <f:entry field="disableChangeLog" title="${%Disable Changelog}">
+      <f:checkbox/>
+    </f:entry>
   </f:advanced>
 
   <t:listScmBrowsers name="mercurial.browser" />

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCM/help-disableChangeLog.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCM/help-disableChangeLog.html
@@ -1,0 +1,5 @@
+<div>
+  When checked, Hudson will not calculate the Mercurial changelog for each build.
+  Disabling the changelog can decrease the amount of time needed to update a
+  very large repository.
+</div>

--- a/src/test/java/hudson/plugins/mercurial/DisableChangeLogTest.java
+++ b/src/test/java/hudson/plugins/mercurial/DisableChangeLogTest.java
@@ -1,0 +1,53 @@
+package hudson.plugins.mercurial;
+
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+import hudson.tools.ToolProperty;
+
+import java.io.File;
+import java.util.Collections;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class DisableChangeLogTest {
+    @Rule public JenkinsRule j = new JenkinsRule();
+    @Rule public MercurialRule m = new MercurialRule(j);
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+    private File repo;
+
+    private static final String DISABLE_CHANGELOG_INSTALLATION = "changelog";
+
+    @Before public void setUp() throws Exception {
+        repo = tmp.getRoot();
+        j.jenkins
+                .getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
+                .setInstallations(
+                        new MercurialInstallation(DISABLE_CHANGELOG_INSTALLATION, "", "hg",
+                                true, false, false, Collections
+                                        .<ToolProperty<?>> emptyList()));
+    }
+
+    protected String hgInstallation() {
+        return DISABLE_CHANGELOG_INSTALLATION;
+    }
+
+    @Test public void changelogIsDisabled() throws Exception {
+        AbstractBuild<?, ?> b;
+        FreeStyleProject p = j.createFreeStyleProject();
+        p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(),
+                MercurialSCM.RevisionType.BRANCH, null, null,
+                null, null, false, null, true));
+        m.hg(repo, "init");
+        m.touchAndCommit(repo, "dir1/f1");
+        b = p.scheduleBuild2(0).get();
+        assertTrue(b.getChangeSet().isEmptySet());
+        m.touchAndCommit(repo, "dir2/f1");
+        b = p.scheduleBuild2(0).get();
+        assertTrue(b.getChangeSet().isEmptySet());
+    }
+}


### PR DESCRIPTION
In some very very large repositories, the changelog calculation can take quite a bit of time. For users that do not care about seeing the changelog in Jenkins, this allows disabling the calculation, thus speeding up builds.

Our Jenkins infrastructure often needs to build older branches followed by newer branches and so on. On top of that, our Mercurial repository is extremely large. Calculating the changelog on this large repository can sometimes take 10-20 minutes. Since we don't really care about displaying the changelog in Jenkins (it becomes meaningless given the large number of commits), it would be great to disable this and decrease build times.

This is a second try of #52, based on Jesse's comments.

[JENKINS-16654](https://issues.jenkins-ci.org/browse/JENKINS-16654)
