### PR TITLE
Add an option to perform a full clone

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -110,6 +110,8 @@ public class MercurialSCM extends SCM implements Serializable {
 
     private final String credentialsId;
 
+    private final boolean fullClone;
+
     private final boolean disableChangeLog;
 
     @Deprecated
@@ -124,10 +126,10 @@ public class MercurialSCM extends SCM implements Serializable {
 
     @Deprecated
     public MercurialSCM(String installation, String source, @NonNull RevisionType revisionType, @NonNull String revision, String modules, String subdir, HgBrowser browser, boolean clean, String credentialsId) {
-      this(installation, source, revisionType, revision, modules, subdir, browser, clean, credentialsId, false);
+      this(installation, source, revisionType, revision, modules, subdir, browser, clean, credentialsId, false, false);
     }
 
-    @DataBoundConstructor public MercurialSCM(String installation, String source, @NonNull RevisionType revisionType, @NonNull String revision, String modules, String subdir, HgBrowser browser, boolean clean, String credentialsId, boolean disableChangeLog) {
+    @DataBoundConstructor public MercurialSCM(String installation, String source, @NonNull RevisionType revisionType, @NonNull String revision, String modules, String subdir, HgBrowser browser, boolean clean, String credentialsId, boolean fullClone, boolean disableChangeLog) {
         this.installation = installation;
         this.source = Util.fixEmptyAndTrim(source);
         this.modules = Util.fixNull(modules);
@@ -138,6 +140,7 @@ public class MercurialSCM extends SCM implements Serializable {
         this.revision = Util.fixEmpty(revision) == null ? (revisionType == RevisionType.BRANCH ? "default" : "???") : revision;
         this.browser = browser;
         this.credentialsId = credentialsId;
+        this.fullClone = fullClone;
         this.disableChangeLog = disableChangeLog;
     }
 
@@ -189,6 +192,10 @@ public class MercurialSCM extends SCM implements Serializable {
 
     public String getCredentialsId() {
         return credentialsId;
+    }
+
+    public boolean isFullClone() {
+        return fullClone;
     }
 
     public boolean isDisableChangeLog() {
@@ -684,7 +691,7 @@ public class MercurialSCM extends SCM implements Serializable {
             }
         } else {
             args.add("clone");
-            if (revisionType == RevisionType.BRANCH) {
+            if (!isFullClone() && revisionType == RevisionType.BRANCH) {
                 args.add("--rev", toRevision);
             }
             args.add("--noupdate");

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCM/config.jelly
@@ -34,6 +34,9 @@
     <f:entry field="subdir" title="${%Subdirectory}">
       <f:textbox/>
     </f:entry>
+    <f:entry field="fullClone" title="${%Full Clone}">
+      <f:checkbox/>
+    </f:entry>
     <f:entry field="disableChangeLog" title="${%Disable Changelog}">
       <f:checkbox/>
     </f:entry>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCM/help-fullClone.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCM/help-fullClone.html
@@ -1,0 +1,13 @@
+<div>
+  Clone the entire repository.
+  <p>
+  Without this option, Hudson clones repositories using the <code>--rev</code> option.  The
+  clone will contain only the specified changesets and their ancestors.  On very large
+  repositories, ancestor calculation can increase clone time and load on the Mercurial
+  server.
+  </p>
+  <p>
+  With this option, Hudson will do a full clone.  On very large repositories this
+  can decrease clone times at the expense of larger clones.
+  </p>
+</div>

--- a/src/test/java/hudson/plugins/mercurial/DisableChangeLogTest.java
+++ b/src/test/java/hudson/plugins/mercurial/DisableChangeLogTest.java
@@ -41,7 +41,7 @@ public class DisableChangeLogTest {
         FreeStyleProject p = j.createFreeStyleProject();
         p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(),
                 MercurialSCM.RevisionType.BRANCH, null, null,
-                null, null, false, null, true));
+                null, null, false, null, false, true));
         m.hg(repo, "init");
         m.touchAndCommit(repo, "dir1/f1");
         b = p.scheduleBuild2(0).get();

--- a/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
+++ b/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
@@ -90,6 +90,19 @@ public abstract class SCMTestBase {
         assertClone(log, false);
     }
 
+    @Test public void fullClone() throws Exception {
+      FreeStyleProject p = j.createFreeStyleProject();
+      p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(),
+              MercurialSCM.RevisionType.BRANCH, null, null,
+              null, null, false, null, true, false));
+      m.hg(repo, "init");
+      m.touchAndCommit(repo, "a");
+      String log = m.buildAndCheck(p, "a");
+      assertTrue(log, log.contains(" clone "));
+      assertFalse(log, log.contains(" clone --rev"));
+      assertTrue(log, log.contains(" update --rev"));
+    }
+
     @Bug(4281)
     @Test public void branches() throws Exception {
         m.hg(repo, "init");


### PR DESCRIPTION
By default, the plugin performs clones with the `--rev` option. According to the Mercurial man page, this:

```
To pull only a subset of changesets, specify one or more
revisions identifiers with -r/--rev or branches with
-b/--branch. The resulting clone will contain only the
specified changesets and their ancestors.
```

On very large repositories, the ancestor calculation can put a large load on the Mercurial server, resulting in slow clone times.  Doing a full clone is actually much quicker, even though the clone is larger.  For example, on our largest repository (500k+ files, 40k+ changesets) this reduces initial clone times from 3.5 hours to 25 minutes!

This adds an option for doing a full clone.  To stay backwards compatible, full clones are off by default.

**NOTE:** Since version 1.50 hasn't been released yet, I didn't add a new deprecated constructor.  If you'd rather I add this, just let me know.
