### PR TITLE
Ignore scheme and port when loose matching clone URLs

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
@@ -53,38 +53,12 @@ public class MercurialStatus extends AbstractModelObject implements UnprotectedR
     public String getUrlName() {
         return "mercurial";
     }
-    
-    private static int getPort(URI uri) {
-        int port = uri.getPort();
-        if ( port < 0 ){
-            String scheme = uri.getScheme();
-            if ("http".equals(scheme)){
-                port = 80;
-            } else if ("https".equals(scheme)) {
-                port = 443;
-            } else if ("ssh".equals(scheme)) {
-                port = 22;
-            }
-        }
-        return port;
-    }
 
-	@Nonnull
-	private static String getScheme(URI uri) {
-		String scheme = uri.getScheme();
-		if (scheme == null) {
-			return "file";
-		}
-		return scheme;
-	}
-    
     static boolean looselyMatches(URI notifyUri, String repository) {
         boolean result = false;
         try {
             URI repositoryUri = new URI(repository);
-            result = getScheme(notifyUri).equals(getScheme(repositoryUri))
-                && Objects.equal(notifyUri.getHost(), repositoryUri.getHost()) 
-                && getPort(notifyUri) == getPort(repositoryUri)
+            result = Objects.equal(notifyUri.getHost(), repositoryUri.getHost())
                 && Objects.equal(notifyUri.getPath(), repositoryUri.getPath())
                 && Objects.equal(notifyUri.getQuery(), repositoryUri.getQuery());
         } catch ( URISyntaxException ex ) {

--- a/src/test/java/hudson/plugins/mercurial/MercurialStatusTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialStatusTest.java
@@ -52,18 +52,26 @@ public class MercurialStatusTest {
       assertTrue( MercurialStatus.looselyMatches(new URI("ssh://somehost/path"), "ssh://user:password@somehost:22/path"));
 
       assertFalse( MercurialStatus.looselyMatches(new URI("ssh://somehost/path"), "invalid/url") );
-      assertFalse( MercurialStatus.looselyMatches(new URI("ssh://somehost/path"), "http://somehost/path") );
       assertFalse( MercurialStatus.looselyMatches(new URI("ssh://somehost/path"), "ssh://somehost/other/path") );
       assertFalse( MercurialStatus.looselyMatches(new URI("ssh://somehost/path"), "ssh://somehost/other/path") );
       assertFalse( MercurialStatus.looselyMatches(new URI("http://somehost/path"), "http://somehost/") );
       assertFalse( MercurialStatus.looselyMatches(new URI("http://somehost/path"), "http://somehost/path?query=test") );
-      assertFalse( MercurialStatus.looselyMatches(new URI("http://somehost/path"), "http://somehost:81/path") );
       assertTrue( MercurialStatus.looselyMatches(new URI("/var/hg/stuff"), "/var/hg/stuff") );
       assertTrue( MercurialStatus.looselyMatches(new URI("file:///var/hg/stuff"), "/var/hg/stuff") );
       assertTrue( MercurialStatus.looselyMatches(new URI("file:/var/hg/stuff"), "/var/hg/stuff") );
       assertTrue( MercurialStatus.looselyMatches(new URI("/var/hg/stuff"), "file:/var/hg/stuff") );
       assertTrue( MercurialStatus.looselyMatches(new URI("/var/hg/stuff"), "file:///var/hg/stuff") );
       assertTrue( MercurialStatus.looselyMatches(new URI("file:///var/hg/stuff"), "file:///var/hg/stuff") );
+
+      assertTrue( MercurialStatus.looselyMatches(new URI("http://somehost/"), "ssh://somehost/") );
+      assertTrue( MercurialStatus.looselyMatches(new URI("https://somehost/"), "http://somehost/") );
+      assertTrue( MercurialStatus.looselyMatches(new URI("ssh://somehost/"), "https://somehost/") );
+      assertTrue( MercurialStatus.looselyMatches(new URI("http://somehost:80/"), "ssh://somehost:22/") );
+      assertTrue( MercurialStatus.looselyMatches(new URI("https://somehost:443/"), "http://somehost:80/") );
+      assertTrue( MercurialStatus.looselyMatches(new URI("ssh://somehost:22/"), "https://somehost:443/") );
+      assertTrue( MercurialStatus.looselyMatches(new URI("http://somehost/path"), "ssh://somehost/path") );
+      assertTrue( MercurialStatus.looselyMatches(new URI("https://somehost/path"), "http://somehost/path") );
+      assertTrue( MercurialStatus.looselyMatches(new URI("ssh://somehost/path"), "https://somehost/path") );
   }
   
 }


### PR DESCRIPTION
This allows users to hit `/notifyCommit` with clone URLs that don't necessarily need to match the protocol (nor port) in the clone URLs configured in the targeted Jenkins jobs.

This also happens to be how the Git Plugin [behaves](https://github.com/jenkinsci/git-plugin/blob/master/src/main/java/hudson/plugins/git/GitStatus.java#L119-L127).
