### PR TITLE
Expand repository source and checkout subdirectory

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/HgExe.java
+++ b/src/main/java/hudson/plugins/mercurial/HgExe.java
@@ -80,7 +80,7 @@ public class HgExe {
 
     @Deprecated
     public HgExe(MercurialSCM scm, Launcher launcher, AbstractBuild build, TaskListener listener) throws IOException, InterruptedException {
-        this(MercurialSCM.findInstallation(scm.getInstallation()), scm.getCredentials(build.getProject()), launcher, build.getBuiltOn(), listener, build.getEnvironment(listener));
+        this(MercurialSCM.findInstallation(scm.getInstallation()), scm.getCredentials(build.getProject(), build.getEnvironment(listener)), launcher, build.getBuiltOn(), listener, build.getEnvironment(listener));
     }
 
     @Deprecated

--- a/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
@@ -2,6 +2,7 @@ package hudson.plugins.mercurial;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
+import hudson.EnvVars;
 import hudson.Extension;
 import hudson.model.AbstractModelObject;
 import hudson.model.Item;

--- a/src/test/java/hudson/plugins/mercurial/EnvVarTest.java
+++ b/src/test/java/hudson/plugins/mercurial/EnvVarTest.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Jesse Glick.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package hudson.plugins.mercurial;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import hudson.tools.ToolProperty;
+import java.io.File;
+import java.util.Collections;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class EnvVarTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public MercurialRule m = new MercurialRule(r);
+    @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test public void customConfiguration() throws Exception {
+        // Define key/value that will be passed to job.
+        final String key = "ENVVARTESTVAR";
+        final String val = "EnvVarTestDir";
+        
+        // Create environment variables from key/value.
+        EnvVars env = new EnvVars( key, val );
+        
+        // 'repo' and 'repoExpanded' should be the same; 'repo' will contain a non expanded environment variable.
+        File repo, repoExpanded;
+        repo = new File( tmp.getRoot() + "/$" + key );
+        repoExpanded = new File( tmp.getRoot() + "/" + val );
+        
+        // Ensure our subdirectory exists.
+        repoExpanded.mkdir( );
+        
+        // Initialise repository.
+        m.hg(repo, env, "init");
+        
+        // We should now have a .hg directory inside our expanded path.
+        assertTrue( new File( repoExpanded + "/.hg" ).getPath( ) + " does not exist", new File( repoExpanded + "/.hg" ).isDirectory( ) );
+        
+        // Touch and commit file.
+        m.touchAndCommit(repoExpanded, "f");
+        
+        // Set up installation.
+        r.jenkins.getDescriptorByType(MercurialInstallation.DescriptorImpl.class).setInstallations(new MercurialInstallation("test", "", "hg", false, false, false, "[format]\nusestore = false", Collections.<ToolProperty<?>>emptyList()));
+ 
+        // Create free style project.
+        FreeStyleProject project = r.createFreeStyleProject();
+        
+        // Create key/value property and add it to the project.
+        ParametersDefinitionProperty pdb = new ParametersDefinitionProperty(
+            new StringParameterDefinition(key, val, "")
+        );
+        project.addProperty(pdb);
+        
+        // Set up SCM.
+        project.setScm(new MercurialSCM("test", repo.getPath(), MercurialSCM.RevisionType.BRANCH, null, null, null, null, false, null, false));
+        
+        // Ensure project builds correctly (again ensures path expansion works).
+        FreeStyleBuild b = r.assertBuildStatusSuccess(project.scheduleBuild2(0));
+        
+        // Catch case where code may see that '/path/$NON_EXPANDED_VAR' doesn't exist, so requests a clone, which succeeds (with the clone being
+        // performed by the hg executable, which will expand the environment correctly. On a second build we'll check if workspace already exists,
+        // if we check '/path/$NON_EXPANDED_VAR' the answer will be no, so a new clone will be triggered, this will fail as an existing repository
+        // will already be checked out there.
+        b = r.assertBuildStatusSuccess(project.scheduleBuild2(0));
+        
+        // Make sure we can get the workspace.
+        FilePath ws = b.getWorkspace();
+        assertNotNull(ws);
+        
+        // Make sure workspace iso kay.
+        String requires = ws.child(".hg/requires").readToString();
+        assertFalse(requires, requires.contains("store"));
+    }
+
+}

--- a/src/test/java/hudson/plugins/mercurial/MercurialRule.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialRule.java
@@ -58,6 +58,10 @@ public final class MercurialRule extends ExternalResource {
         return new HgExe(null, null, launcher(), j.jenkins, listener, new EnvVars());
     }
 
+    private HgExe hgExe(EnvVars env) throws Exception {
+        return new HgExe(null, null, launcher(), j.jenkins, listener, env);
+    }
+
     public void hg(String... args) throws Exception {
         HgExe hg = hgExe();
         assertEquals(0, hg.launch(nobody(hg.seed(false)).add(args)).join());
@@ -66,6 +70,11 @@ public final class MercurialRule extends ExternalResource {
     public void hg(File repo, String... args) throws Exception {
         HgExe hg = hgExe();
         assertEquals(0, hg.launch(nobody(hg.seed(false)).add(args)).pwd(repo).join());
+    }
+
+    public void hg(File repo, EnvVars env, String... args) throws Exception {
+        HgExe hg = hgExe(env);
+        assertEquals(0, hg.launch(nobody(hg.seed(false)).add(args)).envs( env ).pwd(new File(env.expand(repo.getPath()))).join());
     }
 
     private static ArgumentListBuilder nobody(ArgumentListBuilder args) {


### PR DESCRIPTION
This allows environment/build parameters to work (required for inheritance plug-in).

My previous pull request for this was rejected because there were a few ends not tied up and there wasn't a unit test provided. I have spent tonight finding out how to create a unit test, and hope the provided one (EnvVarTest.java) is suitable. The idea is to clone into a subdirectory of the workspace, where the subdirectory is provided as an unexpanded environment variable. With the rest of my changes, this will be correct expanded allowing the build (and subsequent builds thereafter) to work.
