### PR TITLE
Add support for kallithea

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/browser/Kallithea.java
+++ b/src/main/java/hudson/plugins/mercurial/browser/Kallithea.java
@@ -1,0 +1,34 @@
+package hudson.plugins.mercurial.browser;
+
+import hudson.Extension;
+import hudson.util.FormValidation;
+
+import java.net.MalformedURLException;
+
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * Mercurial web interface served using a <a
+ * href="https://kallithea-scm.org/">Kallithea</a> repository.
+ */
+public class Kallithea extends RhodeCode {
+
+    @DataBoundConstructor
+    public Kallithea(String url) throws MalformedURLException {
+        super(url);
+    }
+
+    @Extension
+    public static class DescriptorImpl extends HgBrowser.HgBrowserDescriptor {
+        public String getDisplayName() {
+            return "kallithea";
+        }
+
+        @Override public FormValidation doCheckUrl(@QueryParameter String url) {
+            return _doCheckUrl(url);
+        }
+
+    }
+}


### PR DESCRIPTION
Add support for Kallithea (it is a fork of rhodeCode : https://kallithea-scm.org/). I don't know if add this directly in the mercurial plugin is the best way.