### PR TITLE
[JENKINS-10706] Add env variable MERCURIAL_REVISION_BRANCH

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/HgExe.java
+++ b/src/main/java/hudson/plugins/mercurial/HgExe.java
@@ -55,6 +55,8 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.TimeUnit;
@@ -359,6 +361,24 @@ public class HgExe {
             return null;
         }
         return branch;
+    }
+
+    /**
+     * Gets the version of used Mercurial installation.
+     */
+    public @CheckForNull String version() throws IOException, InterruptedException {
+        String version = popen(null, listener, false, new ArgumentListBuilder("version"));
+        if (version.isEmpty()) {
+            listener.error(Messages.HgExe_expected_to_get_hg_version_name_but_got_nothing());
+            return null;
+        }
+        Matcher m = Pattern.compile("^Mercurial Distributed SCM \\(version ([0-9][^)]*)\\)").matcher(version);
+        if (!m.lookingAt() || m.groupCount() < 1)
+        {
+            listener.error(Messages.HgExe_cannot_extract_hg_version());
+            return null;
+        }
+        return m.group(1);
     }
 
     /**

--- a/src/main/java/hudson/plugins/mercurial/HgExe.java
+++ b/src/main/java/hudson/plugins/mercurial/HgExe.java
@@ -351,7 +351,7 @@ public class HgExe {
      * Gets the branch name of given revision number or of the current workspace.
      * @param rev the revision to identify; defaults to current working copy
      */
-    public @CheckForNull String branch(FilePath repository, @Nullable String rev) throws IOException, InterruptedException {
+    public @CheckForNull String branch(FilePath repository, @CheckForNull String rev) throws IOException, InterruptedException {
         ArgumentListBuilder builder = new ArgumentListBuilder("id", "--branch");
         if (rev != null)
             builder.add("--rev", rev);

--- a/src/main/java/hudson/plugins/mercurial/HgExe.java
+++ b/src/main/java/hudson/plugins/mercurial/HgExe.java
@@ -346,6 +346,22 @@ public class HgExe {
     }
 
     /**
+     * Gets the branch name of given revision number or of the current workspace.
+     * @param rev the revision to identify; defaults to current working copy
+     */
+    public @CheckForNull String branch(FilePath repository, @Nullable String rev) throws IOException, InterruptedException {
+        ArgumentListBuilder builder = new ArgumentListBuilder("id", "--branch");
+        if (rev != null)
+            builder.add("--rev", rev);
+        String branch = popen(repository, listener, false, builder).trim();
+        if (branch.isEmpty()) {
+            listener.error(Messages.HgExe_expected_to_get_a_branch_name_but_got_nothing());
+            return null;
+        }
+        return branch;
+    }
+
+    /**
      * Gets the current value of a specified config item.
      */
     public String config(FilePath repository, String name) throws IOException, InterruptedException {

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -73,6 +73,7 @@ public class MercurialSCM extends SCM implements Serializable {
     private static final String ENV_MERCURIAL_REVISION = "MERCURIAL_REVISION";
     private static final String ENV_MERCURIAL_REVISION_SHORT = "MERCURIAL_REVISION_SHORT";
     private static final String ENV_MERCURIAL_REVISION_NUMBER = "MERCURIAL_REVISION_NUMBER";
+    private static final String ENV_MERCURIAL_REVISION_BRANCH = "MERCURIAL_REVISION_BRANCH";
     private static final String ENV_MERCURIAL_REPOSITORY_URL = "MERCURIAL_REPOSITORY_URL";
 
     // old fields are left so that old config data can be read in, but
@@ -352,7 +353,8 @@ public class MercurialSCM extends SCM implements Serializable {
         try {
         String tip = hg.tip(workspace2Repo(workspace, env), null);
         String rev = hg.tipNumber(workspace2Repo(workspace, env), null);
-        return tip != null && rev != null ? new MercurialTagAction(tip, rev, getSubdir(env)) : null;
+        String branch = revisionType == RevisionType.TAG ? hg.branch(workspace2Repo(workspace, env), null) : null;
+        return tip != null && rev != null ? new MercurialTagAction(tip, rev, getSubdir(env), branch) : null;
         } finally {
             hg.close();
         }
@@ -420,6 +422,7 @@ public class MercurialSCM extends SCM implements Serializable {
         String _revision = getRevisionExpanded(project, env);
         String remote = hg.tip(repository, _revision);
         String rev = hg.tipNumber(repository, _revision);
+        String branch = revisionType == RevisionType.TAG ? hg.branch(repository, _revision) : null;
 
         if (remote == null) {
             throw new IOException("failed to find ID of branch head");
@@ -428,11 +431,11 @@ public class MercurialSCM extends SCM implements Serializable {
             throw new IOException("failed to find revision of branch head");
         }
         if (remote.equals(baseline.id)) { // shortcut
-            return new PollingResult(baseline, new MercurialTagAction(remote, rev, getSubdir(env)), Change.NONE);
+            return new PollingResult(baseline, new MercurialTagAction(remote, rev, getSubdir(env), branch), Change.NONE);
         }
         Set<String> changedFileNames = parseStatus(hg.popen(repository, listener, false, new ArgumentListBuilder("status", "--rev", baseline.id, "--rev", remote)));
 
-        MercurialTagAction cur = new MercurialTagAction(remote, rev, getSubdir(env));
+        MercurialTagAction cur = new MercurialTagAction(remote, rev, getSubdir(env), branch);
         return new PollingResult(baseline,cur,computeDegreeOfChanges(changedFileNames,output));
         } finally {
             hg.close();
@@ -709,8 +712,9 @@ public class MercurialSCM extends SCM implements Serializable {
 
         String tip = hg.tip(repository, null);
         String rev = hg.tipNumber(repository, null);
+        String branch = revisionType == RevisionType.TAG ? hg.branch(repository, null) : null;
         if (tip != null && rev != null) {
-            build.addAction(new MercurialTagAction(tip, rev, getSubdir(env)));
+            build.addAction(new MercurialTagAction(tip, rev, getSubdir(env), branch));
         }
         } finally {
             hg.close();
@@ -820,8 +824,9 @@ public class MercurialSCM extends SCM implements Serializable {
 
         String tip = hg.tip(repository, null);
         String rev = hg.tipNumber(repository, null);
+        String branch = revisionType == RevisionType.TAG ? hg.branch(repository, null) : null;
         if (tip != null && rev != null) {
-            build.addAction(new MercurialTagAction(tip, rev, getSubdir(env)));
+            build.addAction(new MercurialTagAction(tip, rev, getSubdir(env), branch));
         }
         } finally {
             hg.close();
@@ -839,6 +844,8 @@ public class MercurialSCM extends SCM implements Serializable {
             env.put(ENV_MERCURIAL_REVISION, a.id);
             env.put(ENV_MERCURIAL_REVISION_SHORT, a.getShortId());
             env.put(ENV_MERCURIAL_REVISION_NUMBER, a.rev);
+            if (revisionType == RevisionType.TAG)
+                env.put(ENV_MERCURIAL_REVISION_BRANCH, a.getBranch());
             env.put(ENV_MERCURIAL_REPOSITORY_URL, this.getSource());
         }
     }

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -37,6 +37,7 @@ import hudson.scm.SCMRevisionState;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.ForkOutputStream;
 import hudson.util.ListBoxModel;
+import hudson.util.VersionNumber;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -769,6 +770,9 @@ public class MercurialSCM extends SCM implements Serializable {
                 args.add("share");
                 args.add("--noupdate");
                 args.add(cachedSource.getRepoLocation());
+                if (new VersionNumber(hg.version()).compareTo(new VersionNumber("3.3")) >= 0) {
+                    args.add("-B");
+                }
             } else {
                 args.add("clone");
                 args.add("--noupdate");

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -353,7 +353,7 @@ public class MercurialSCM extends SCM implements Serializable {
         try {
         String tip = hg.tip(workspace2Repo(workspace, env), null);
         String rev = hg.tipNumber(workspace2Repo(workspace, env), null);
-        String branch = revisionType == RevisionType.TAG ? hg.branch(workspace2Repo(workspace, env), null) : null;
+        String branch = revisionType != RevisionType.BRANCH ? hg.branch(workspace2Repo(workspace, env), null) : null;
         return tip != null && rev != null ? new MercurialTagAction(tip, rev, getSubdir(env), branch) : null;
         } finally {
             hg.close();
@@ -422,7 +422,7 @@ public class MercurialSCM extends SCM implements Serializable {
         String _revision = getRevisionExpanded(project, env);
         String remote = hg.tip(repository, _revision);
         String rev = hg.tipNumber(repository, _revision);
-        String branch = revisionType == RevisionType.TAG ? hg.branch(repository, _revision) : null;
+        String branch = revisionType != RevisionType.BRANCH ? hg.branch(repository, _revision) : null;
 
         if (remote == null) {
             throw new IOException("failed to find ID of branch head");
@@ -712,7 +712,7 @@ public class MercurialSCM extends SCM implements Serializable {
 
         String tip = hg.tip(repository, null);
         String rev = hg.tipNumber(repository, null);
-        String branch = revisionType == RevisionType.TAG ? hg.branch(repository, null) : null;
+        String branch = revisionType != RevisionType.BRANCH ? hg.branch(repository, null) : null;
         if (tip != null && rev != null) {
             build.addAction(new MercurialTagAction(tip, rev, getSubdir(env), branch));
         }
@@ -824,7 +824,7 @@ public class MercurialSCM extends SCM implements Serializable {
 
         String tip = hg.tip(repository, null);
         String rev = hg.tipNumber(repository, null);
-        String branch = revisionType == RevisionType.TAG ? hg.branch(repository, null) : null;
+        String branch = revisionType != RevisionType.BRANCH ? hg.branch(repository, null) : null;
         if (tip != null && rev != null) {
             build.addAction(new MercurialTagAction(tip, rev, getSubdir(env), branch));
         }
@@ -844,7 +844,7 @@ public class MercurialSCM extends SCM implements Serializable {
             env.put(ENV_MERCURIAL_REVISION, a.id);
             env.put(ENV_MERCURIAL_REVISION_SHORT, a.getShortId());
             env.put(ENV_MERCURIAL_REVISION_NUMBER, a.rev);
-            if (revisionType == RevisionType.TAG)
+            if (revisionType != RevisionType.BRANCH)
                 env.put(ENV_MERCURIAL_REVISION_BRANCH, a.getBranch());
             env.put(ENV_MERCURIAL_REPOSITORY_URL, this.getSource());
         }

--- a/src/main/java/hudson/plugins/mercurial/MercurialTagAction.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialTagAction.java
@@ -32,10 +32,16 @@ public class MercurialTagAction extends SCMRevisionState {
      */
     public final String subdir;
 
-    public MercurialTagAction(@NonNull String id, @NonNull String rev, @Nullable String subdir) {
+    /**
+    * Branch name of current revision.
+    */
+    public final String branch;
+
+    public MercurialTagAction(@NonNull String id, @NonNull String rev, @Nullable String subdir, @Nullable String branch) {
         this.id = id;
         this.rev = rev;
         this.subdir = subdir;
+        this.branch = branch;
     }
 
     @Exported(name = "mercurialNodeName")
@@ -51,6 +57,11 @@ public class MercurialTagAction extends SCMRevisionState {
     @Exported
     public String getSubdir() {
         return subdir;
+    }
+
+    @Exported(name = "mercurialRevisionBranch")
+    public String getBranch() {
+        return branch;
     }
 
     /**

--- a/src/main/resources/hudson/plugins/mercurial/Messages.properties
+++ b/src/main/resources/hudson/plugins/mercurial/Messages.properties
@@ -1,4 +1,5 @@
 HgExe.expected_to_get_a_revision_number_but_got_instead=Expected to get a revision number but got ''{0}'' instead.
+HgExe.expected_to_get_a_branch_name_but_got_nothing=Expected to get a branch name but got an empty name instead.
 MercurialInstallation.mercurial=Mercurial
 MercurialSCM.dependent_changes_detected=Dependent changes detected
 MercurialSCM.failed_to_clone=Failed to clone {0}

--- a/src/main/resources/hudson/plugins/mercurial/Messages.properties
+++ b/src/main/resources/hudson/plugins/mercurial/Messages.properties
@@ -1,5 +1,7 @@
 HgExe.expected_to_get_a_revision_number_but_got_instead=Expected to get a revision number but got ''{0}'' instead.
 HgExe.expected_to_get_a_branch_name_but_got_nothing=Expected to get a branch name but got an empty name instead.
+HgExe.expected_to_get_hg_version_name_but_got_nothing=Expected to get a mercurial version but got an empty string instead.
+HgExe.cannot_extract_hg_version=Cannot extract hg version
 MercurialInstallation.mercurial=Mercurial
 MercurialSCM.dependent_changes_detected=Dependent changes detected
 MercurialSCM.failed_to_clone=Failed to clone {0}

--- a/src/test/java/hudson/plugins/mercurial/ChangeComparatorTest.java
+++ b/src/test/java/hudson/plugins/mercurial/ChangeComparatorTest.java
@@ -54,7 +54,7 @@ public class ChangeComparatorTest {
         PollingResult pr = scm.compare(
 				launcher, 
 				listener, 
-				new MercurialTagAction("tip","",null,"default"),
+				new MercurialTagAction("tip","",null,null),
 				listener.getLogger(), 
 				Computer.currentComputer().getNode(), 
 				new FilePath(tmp.getRoot()), 

--- a/src/test/java/hudson/plugins/mercurial/ChangeComparatorTest.java
+++ b/src/test/java/hudson/plugins/mercurial/ChangeComparatorTest.java
@@ -54,7 +54,7 @@ public class ChangeComparatorTest {
         PollingResult pr = scm.compare(
 				launcher, 
 				listener, 
-				new MercurialTagAction("tip","",null), 
+				new MercurialTagAction("tip","",null,"default"),
 				listener.getLogger(), 
 				Computer.currentComputer().getNode(), 
 				new FilePath(tmp.getRoot()), 

--- a/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
+++ b/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
@@ -42,6 +42,8 @@ import org.apache.commons.io.FileUtils;
 import static org.junit.Assert.assertEquals;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -120,4 +122,14 @@ public class HgExeFunctionalTest {
         assertEquals("hg --config defaults.clone=--uncompressed clone http://some.thing/", b.toString());
     }
 
+    @Test public void checkVersion() throws Exception {
+        HgExe hgexe = new HgExe(
+                this.mercurialInstallation, null,
+                this.launcher, j.jenkins,
+                this.listener, this.vars);
+        String version = hgexe.version();
+        assertNotNull(version);
+        assertTrue(version.length() >= 3); // min: X.Y
+        assertTrue(version.length() <= 8); // max: XX.YY.ZZ
+    }
 }

--- a/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
+++ b/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
@@ -33,6 +33,7 @@ import hudson.model.TaskListener;
 import hudson.tools.ToolProperty;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.StreamTaskListener;
+import hudson.util.VersionNumber;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.util.Collections;
@@ -129,7 +130,6 @@ public class HgExeFunctionalTest {
                 this.listener, this.vars);
         String version = hgexe.version();
         assertNotNull(version);
-        assertTrue(version.length() >= 3); // min: X.Y
-        assertTrue(version.length() <= 8); // max: XX.YY.ZZ
+        assertTrue(new VersionNumber(version).compareTo(new VersionNumber("1.0")) >= 0);
     }
 }

--- a/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
@@ -52,7 +52,7 @@ public class MercurialSCMTest {
         final String EXPECTED_SHORT_ID = "123456789012";
         new MercurialSCM("","","", "", "", null, true).buildEnvVarsFromActionable(new Actionable() {
             @Override public List<Action> getActions() {
-                return Collections.<Action>singletonList(new MercurialTagAction(EXPECTED_SHORT_ID + "1627e63489b4096a8858e559a456", "rev", null));
+                return Collections.<Action>singletonList(new MercurialTagAction(EXPECTED_SHORT_ID + "1627e63489b4096a8858e559a456", "rev", null, "default"));
             }
             @Override public String getDisplayName() {return null;}
             @Override public String getSearchUrl() {return null;}
@@ -65,7 +65,7 @@ public class MercurialSCMTest {
         final String EXPECTED_REPOSITORY_URL = "http://mercurialserver/testrepo";
         new MercurialSCM("",EXPECTED_REPOSITORY_URL,"", "", "", null, true).buildEnvVarsFromActionable(new Actionable() {
             @Override public List<Action> getActions() {
-                return Collections.<Action>singletonList(new MercurialTagAction("1627e63489b4096a8858e559a456", "rev", null));            }
+                return Collections.<Action>singletonList(new MercurialTagAction("1627e63489b4096a8858e559a456", "rev", null, "default"));            }
             @Override public String getDisplayName() {return null;}
             @Override public String getSearchUrl() {return null;}
         }, actualEnvironment);

--- a/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
@@ -52,7 +52,7 @@ public class MercurialSCMTest {
         final String EXPECTED_SHORT_ID = "123456789012";
         new MercurialSCM("","","", "", "", null, true).buildEnvVarsFromActionable(new Actionable() {
             @Override public List<Action> getActions() {
-                return Collections.<Action>singletonList(new MercurialTagAction(EXPECTED_SHORT_ID + "1627e63489b4096a8858e559a456", "rev", null, "default"));
+                return Collections.<Action>singletonList(new MercurialTagAction(EXPECTED_SHORT_ID + "1627e63489b4096a8858e559a456", "rev", null, null));
             }
             @Override public String getDisplayName() {return null;}
             @Override public String getSearchUrl() {return null;}
@@ -65,7 +65,7 @@ public class MercurialSCMTest {
         final String EXPECTED_REPOSITORY_URL = "http://mercurialserver/testrepo";
         new MercurialSCM("",EXPECTED_REPOSITORY_URL,"", "", "", null, true).buildEnvVarsFromActionable(new Actionable() {
             @Override public List<Action> getActions() {
-                return Collections.<Action>singletonList(new MercurialTagAction("1627e63489b4096a8858e559a456", "rev", null, "default"));            }
+                return Collections.<Action>singletonList(new MercurialTagAction("1627e63489b4096a8858e559a456", "rev", null, null));            }
             @Override public String getDisplayName() {return null;}
             @Override public String getSearchUrl() {return null;}
         }, actualEnvironment);

--- a/src/test/java/hudson/plugins/mercurial/MercurialTagActionTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialTagActionTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertEquals;
 
 public class MercurialTagActionTest {
     @Test public void getShortIdReturnsFirstTwelveCharactersOfId(){
-        MercurialTagAction action = new MercurialTagAction("1234567890121627e63489b4096a8858e559a456", "", "");
+        MercurialTagAction action = new MercurialTagAction("1234567890121627e63489b4096a8858e559a456", "", "", "default");
 
         assertEquals("123456789012", action.getShortId());
     }

--- a/src/test/java/hudson/plugins/mercurial/MercurialTagActionTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialTagActionTest.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertEquals;
 
 public class MercurialTagActionTest {
     @Test public void getShortIdReturnsFirstTwelveCharactersOfId(){
-        MercurialTagAction action = new MercurialTagAction("1234567890121627e63489b4096a8858e559a456", "", "", "default");
+        MercurialTagAction action = new MercurialTagAction("1234567890121627e63489b4096a8858e559a456", "", "", null);
 
         assertEquals("123456789012", action.getShortId());
     }

--- a/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
+++ b/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
@@ -755,24 +755,26 @@ public abstract class SCMTestBase {
         m.hg(repo, "update", "--clean", "default");
     }
 
+    @Bug(10706)
     @Test public void testGetBranchFromTag() throws Exception {
         initRepoWithTag();
         FreeStyleProject p = j.createFreeStyleProject();
         p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(), MercurialSCM.RevisionType.TAG, "release", null, null, null, false, null));
 
-        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+        FreeStyleBuild b = j.buildAndAssertSuccess(p);
         MercurialTagAction action = b.getAction(MercurialTagAction.class);
         assertNotNull(action);
         assertEquals("stable", action.getBranch());
         assertEquals("stable", b.getEnvironment().get("MERCURIAL_REVISION_BRANCH"));
     }
 
+    @Bug(10706)
     @Test public void testGetNoBranchFromBranch() throws Exception {
         initRepoWithTag();
         FreeStyleProject p = j.createFreeStyleProject();
         p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(), MercurialSCM.RevisionType.BRANCH, "default", null, null, null, false, null));
 
-        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+        FreeStyleBuild b = j.buildAndAssertSuccess(p);
         MercurialTagAction action = b.getAction(MercurialTagAction.class);
         assertNotNull(action);
         assertEquals(null, action.getBranch());

--- a/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
+++ b/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
@@ -746,17 +746,17 @@ public abstract class SCMTestBase {
         assertEquals(Result.SUCCESS, b.getResult());
     }
 
-    private void initRepoWithBookmark() throws Exception {
+    private void initRepoWithTag() throws Exception {
         m.hg(repo, "init");
         m.touchAndCommit(repo, "init");
         m.hg(repo, "branch", "stable");
         m.touchAndCommit(repo, "stable commit");
+        m.hg(repo, "tag", "release");
         m.hg(repo, "update", "--clean", "default");
-        m.hg(repo, "bookmark", "--rev", "stable", "release");
     }
 
     @Test public void testGetBranchFromTag() throws Exception {
-        initRepoWithBookmark();
+        initRepoWithTag();
         FreeStyleProject p = j.createFreeStyleProject();
         p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(), MercurialSCM.RevisionType.TAG, "release", null, null, null, false, null));
 
@@ -768,7 +768,7 @@ public abstract class SCMTestBase {
     }
 
     @Test public void testGetNoBranchFromBranch() throws Exception {
-        initRepoWithBookmark();
+        initRepoWithTag();
         FreeStyleProject p = j.createFreeStyleProject();
         p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(), MercurialSCM.RevisionType.BRANCH, "default", null, null, null, false, null));
 

--- a/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
+++ b/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
@@ -764,7 +764,7 @@ public abstract class SCMTestBase {
         MercurialTagAction action = b.getAction(MercurialTagAction.class);
         assertNotNull(action);
         assertEquals("stable", action.getBranch());
-        assertEquals("stable", b.getEnvironment().get("MERCURIAL_REVISION_BRANCH", ""));
+        assertEquals("stable", b.getEnvironment().get("MERCURIAL_REVISION_BRANCH"));
     }
 
     @Test public void testGetNoBranchFromBranch() throws Exception {
@@ -776,7 +776,7 @@ public abstract class SCMTestBase {
         MercurialTagAction action = b.getAction(MercurialTagAction.class);
         assertNotNull(action);
         assertEquals(null, action.getBranch());
-        assertEquals("", b.getEnvironment().get("MERCURIAL_REVISION_BRANCH", ""));
+        assertEquals(null, b.getEnvironment().get("MERCURIAL_REVISION_BRANCH"));
     }
 
     /* TODO the following will pass, but canUpdate is not going to work without further changes:


### PR DESCRIPTION
Hi!
I added support to get branch name of current or given revision. So build jobs can use MERCURIAL_REVISION_BRANCH to get the branch of tested revision.

https://issues.jenkins-ci.org/browse/JENKINS-10706
