### PR TITLE
Expose new environment variable MERCURIAL_REPOSITORY_URL

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -68,6 +68,13 @@ import org.kohsuke.stapler.StaplerRequest;
  * Mercurial SCM.
  */
 public class MercurialSCM extends SCM implements Serializable {
+
+    // Environment vars names to be exposed
+    private static final String ENV_MERCURIAL_REVISION = "MERCURIAL_REVISION";
+    private static final String ENV_MERCURIAL_REVISION_SHORT = "MERCURIAL_REVISION_SHORT";
+    private static final String ENV_MERCURIAL_REVISION_NUMBER = "MERCURIAL_REVISION_NUMBER";
+    private static final String ENV_MERCURIAL_REPOSITORY_URL = "MERCURIAL_REPOSITORY_URL";
+
     // old fields are left so that old config data can be read in, but
     // they are deprecated. transient so that they won't show up in XML
     // when writing back
@@ -829,9 +836,10 @@ public class MercurialSCM extends SCM implements Serializable {
     void buildEnvVarsFromActionable(Actionable build, Map<String, String> env) {
         MercurialTagAction a = findTag(build, new EnvVars(env));
         if (a != null) {
-            env.put("MERCURIAL_REVISION", a.id);
-            env.put("MERCURIAL_REVISION_SHORT", a.getShortId());
-            env.put("MERCURIAL_REVISION_NUMBER", a.rev);
+            env.put(ENV_MERCURIAL_REVISION, a.id);
+            env.put(ENV_MERCURIAL_REVISION_SHORT, a.getShortId());
+            env.put(ENV_MERCURIAL_REVISION_NUMBER, a.rev);
+            env.put(ENV_MERCURIAL_REPOSITORY_URL, this.getSource());
         }
     }
 

--- a/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
@@ -60,4 +60,16 @@ public class MercurialSCMTest {
         assertEquals(EXPECTED_SHORT_ID, actualEnvironment.get("MERCURIAL_REVISION_SHORT"));
     }
 
+    @Test public void buildEnvVarsSetsUrl() throws IOException {
+        Map<String,String> actualEnvironment = new HashMap<String,String>();
+        final String EXPECTED_REPOSITORY_URL = "http://mercurialserver/testrepo";
+        new MercurialSCM("",EXPECTED_REPOSITORY_URL,"", "", "", null, true).buildEnvVarsFromActionable(new Actionable() {
+            @Override public List<Action> getActions() {
+                return Collections.<Action>singletonList(new MercurialTagAction("1627e63489b4096a8858e559a456", "rev", null));            }
+            @Override public String getDisplayName() {return null;}
+            @Override public String getSearchUrl() {return null;}
+        }, actualEnvironment);
+        assertEquals(EXPECTED_REPOSITORY_URL, actualEnvironment.get("MERCURIAL_REPOSITORY_URL"));
+    }
+
 }


### PR DESCRIPTION
This feature is useful when requiring the same repository to be used on downstream jobs (multijob).
Then the upstream job can pass the mercurial repo url to the downstream one. 

Now only the revision can be passed, which needs the repo url config to be duplicated in the downstream jobs..
This PR will simplify the repo config on the downstream jobs a lot (especially when having many ..)

