### PR TITLE
[WiP] [JENKINS-27749] Incoming changeset message regex

### DIFF
--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCM/global.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCM/global.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
+ xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson"  xmlns:f="/lib/form">
+
+<f:section title="Mercurial SCM">
+
+  <f:entry field="commitMessageInclusionRegex" title="Commit Message Inclusion Regex">
+    <f:textbox />
+  </f:entry>
+
+</f:section> 
+</j:jelly>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCM/help-commitMessageInclusionRegex.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCM/help-commitMessageInclusionRegex.html
@@ -1,0 +1,1 @@
+If configured, will include any incoming changesets for changes only if the commit messages which match the pattern specified.

--- a/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
@@ -24,16 +24,34 @@
 
 package hudson.plugins.mercurial;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import hudson.FilePath;
 import hudson.model.Action;
+import hudson.model.TaskListener;
 import hudson.model.Actionable;
-import org.junit.Test;
+import hudson.plugins.mercurial.MercurialSCM.MercurialRevision;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
 
 public class MercurialSCMTest {
+	
+	private static final String COMMIT_MESSAGE_INCLUSION_REGEX = "^INCLUDE:.*";
+	
+	private static final List<String> CHANGED_FILES = Lists.newArrayList("A added","R removed","M modified");
 
     @Test public void parseStatus() throws Exception {
         assertEquals(new HashSet<String>(Arrays.asList("whatever", "added", "mo-re", "whatever-c", "initial", "more")), MercurialSCM.parseStatus(
@@ -54,8 +72,8 @@ public class MercurialSCMTest {
             @Override public List<Action> getActions() {
                 return Collections.<Action>singletonList(new MercurialTagAction(EXPECTED_SHORT_ID + "1627e63489b4096a8858e559a456", "rev", null));
             }
-            @Override public String getDisplayName() {return null;}
-            @Override public String getSearchUrl() {return null;}
+            public String getDisplayName() {return null;}
+            public String getSearchUrl() {return null;}
         }, actualEnvironment);
         assertEquals(EXPECTED_SHORT_ID, actualEnvironment.get("MERCURIAL_REVISION_SHORT"));
     }
@@ -66,10 +84,189 @@ public class MercurialSCMTest {
         new MercurialSCM("",EXPECTED_REPOSITORY_URL,"", "", "", null, true).buildEnvVarsFromActionable(new Actionable() {
             @Override public List<Action> getActions() {
                 return Collections.<Action>singletonList(new MercurialTagAction("1627e63489b4096a8858e559a456", "rev", null));            }
-            @Override public String getDisplayName() {return null;}
-            @Override public String getSearchUrl() {return null;}
+            public String getDisplayName() {return null;}
+            public String getSearchUrl() {return null;}
         }, actualEnvironment);
         assertEquals(EXPECTED_REPOSITORY_URL, actualEnvironment.get("MERCURIAL_REPOSITORY_URL"));
     }
+    
+    @Test public void testGetChangedFileNamesFilteringByRegex_SingleIncludedFound() {
+    	MercurialSCM mercurialSCM = setupNewMercurialSCM(true);
+    	
+    	TaskListener listener = null;
+    	MercurialTagAction baseline = null;
+    	FilePath repository = null;
+    	HgExe hg = null;
+    	String remote = null;
+		
+		Set<String> changedFileNames = null;
+		try {
+			changedFileNames = mercurialSCM
+					.getChangedFileNamesFilteringByRegex(listener, baseline,
+							repository, hg, remote, System.out,
+							COMMIT_MESSAGE_INCLUSION_REGEX);
+		} catch (InterruptedException ie) {
+			Assert.fail("Unexpected InterruptedException: " + ie.getMessage());
+		} catch (IOException ioe) {
+			Assert.fail("Unexpected IOException: " + ioe);
+    	}
+		
+		assertNotNull(changedFileNames);
+		System.out.println("changedFileNames=" + changedFileNames);
+		assertEquals("Should have 1 changedFileNames found",1,changedFileNames.size());
+    }
+
+    @Test public void testGetChangedFileNamesFilteringByRegex_SingleExcludedFound() {
+    	MercurialSCM mercurialSCM = setupNewMercurialSCM(false);
+    	
+    	TaskListener listener = null;
+    	MercurialTagAction baseline = null;
+    	FilePath repository = null;
+    	HgExe hg = null;
+    	String remote = null;
+		
+		Set<String> changedFileNames = null;
+		try {
+			changedFileNames = mercurialSCM
+					.getChangedFileNamesFilteringByRegex(listener, baseline,
+							repository, hg, remote, System.out,
+							COMMIT_MESSAGE_INCLUSION_REGEX);
+		} catch (InterruptedException ie) {
+			Assert.fail("Unexpected InterruptedException: " + ie.getMessage());
+		} catch (IOException ioe) {
+			Assert.fail("Unexpected IOException: " + ioe);
+    	}
+		
+		assertNotNull(changedFileNames);
+		System.out.println("changedFileNames=" + changedFileNames);
+		assertEquals("Should have 0 changedFileNames found",0,changedFileNames.size());
+    }
+
+    @Test public void testGetChangedFileNamesFilteringByRegex_SixIncludedFound() {
+    	MercurialSCM mercurialSCM = setupNewMercurialSCM(true, true, true, true, true, true);
+    	
+    	TaskListener listener = null;
+    	MercurialTagAction baseline = null;
+    	FilePath repository = null;
+    	HgExe hg = null;
+    	String remote = null;
+		
+		Set<String> changedFileNames = null;
+		try {
+			changedFileNames = mercurialSCM
+					.getChangedFileNamesFilteringByRegex(listener, baseline,
+							repository, hg, remote, System.out,
+							COMMIT_MESSAGE_INCLUSION_REGEX);
+		} catch (InterruptedException ie) {
+			Assert.fail("Unexpected InterruptedException: " + ie.getMessage());
+		} catch (IOException ioe) {
+			Assert.fail("Unexpected IOException: " + ioe);
+    	}
+		
+		assertNotNull(changedFileNames);
+		System.out.println("changedFileNames=" + changedFileNames);
+		assertEquals("Should have 3 changedFileNames found",3,changedFileNames.size());
+    }
+
+    @Test public void testGetChangedFileNamesFilteringByRegex_SixExcludedFound() {
+    	MercurialSCM mercurialSCM = setupNewMercurialSCM(false, false, false, false, false, false);
+    	
+    	TaskListener listener = null;
+    	MercurialTagAction baseline = null;
+    	FilePath repository = null;
+    	HgExe hg = null;
+    	String remote = null;
+		
+		Set<String> changedFileNames = null;
+		try {
+			changedFileNames = mercurialSCM
+					.getChangedFileNamesFilteringByRegex(listener, baseline,
+							repository, hg, remote, System.out,
+							COMMIT_MESSAGE_INCLUSION_REGEX);
+		} catch (InterruptedException ie) {
+			Assert.fail("Unexpected InterruptedException: " + ie.getMessage());
+		} catch (IOException ioe) {
+			Assert.fail("Unexpected IOException: " + ioe);
+    	}
+		
+		assertNotNull(changedFileNames);
+		System.out.println("changedFileNames=" + changedFileNames);
+		assertEquals("Should have 0 changedFileNames found",0,changedFileNames.size());
+    }
+
+    @Test public void testGetChangedFileNamesFilteringByRegex_MixOfAlternatingSixIncludedSixExcludedFound() {
+    	MercurialSCM mercurialSCM = setupNewMercurialSCM(true, false, true, false, true, false, true, false, true, false, true, false);
+    	
+    	TaskListener listener = null;
+    	MercurialTagAction baseline = null;
+    	FilePath repository = null;
+    	HgExe hg = null;
+    	String remote = null;
+		
+		Set<String> changedFileNames = null;
+		try {
+			changedFileNames = mercurialSCM
+					.getChangedFileNamesFilteringByRegex(listener, baseline,
+							repository, hg, remote, System.out,
+							COMMIT_MESSAGE_INCLUSION_REGEX);
+		} catch (InterruptedException ie) {
+			Assert.fail("Unexpected InterruptedException: " + ie.getMessage());
+		} catch (IOException ioe) {
+			Assert.fail("Unexpected IOException: " + ioe);
+    	}
+		
+		assertNotNull(changedFileNames);
+		System.out.println("changedFileNames=" + changedFileNames);
+		assertEquals("Should have 3 changedFileNames found",3,changedFileNames.size());
+    }
+
+	private MercurialSCM setupNewMercurialSCM(final boolean... included) {
+		return new MercurialSCM("") {
+			private static final long serialVersionUID = 1L;
+			private Map<Integer,Set<String>> changedFiles = new HashMap<Integer,Set<String>>();
+			private List<MercurialRevision> getRevisionsBetweenReturnValue = setupData(changedFiles,included);
+    		@Override
+    		List<MercurialRevision> getRevisionsBetween(TaskListener listener,
+    				MercurialTagAction baseline, FilePath repository, HgExe hg,
+    				String remote) throws IOException, InterruptedException {
+    			return getRevisionsBetweenReturnValue;
+    		}
+    		@Override
+    		Set<String> getChangedFileNamesBetweenRevisions(
+    				TaskListener listener, FilePath repository, HgExe hg,
+    				String endId, String startId) throws IOException,
+    				InterruptedException {
+    			return changedFiles.get(Integer.valueOf(endId));
+    		}
+    	};
+	}
+    
+    private List<MercurialRevision> setupData(Map<Integer,Set<String>> changedFileNamesBetweenRevisions,boolean... included) {
+    	List<MercurialRevision> returnData = new ArrayList<MercurialRevision>();
+    	returnData.add(new MercurialRevision("baselineRev", "baselineMessage"));
+    	Integer count = 0;
+    	for(boolean include:included) {
+    		changedFileNamesBetweenRevisions.put(count, getChangedFileNames(include, count));
+    		returnData.add(new MercurialRevision(String.valueOf(count), getCommitMessage(count,include)));
+    		count++;
+    	}
+    	System.out.println("Created revision: " + returnData);
+    	return returnData;
+    }
+
+	private Set<String> getChangedFileNames(boolean include, int count) {
+		Set<String> changedFileNames = null;
+		if(include) {
+			changedFileNames = new HashSet<String>();
+			changedFileNames.add(CHANGED_FILES.get(count % 3));
+		}
+		return changedFileNames;
+	}
+
+	private String getCommitMessage(int count, boolean include) {
+		String message = include ? "INCLUDE:" : "EXCLUDE:";
+		message += "message" + count;
+		return message;
+	}
 
 }


### PR DESCRIPTION
[JENKINS-27749](https://issues.jenkins-ci.org/browse/JENKINS-27749)

In my environment, our automated activities have a consistent prefix to their commit messages.  These include, but are not limited to, incrementing version, creating branches, tagging revisions, etc...

I have already installed this plugin in my Jenkins/Ubuntu environment with success.  I have tested both with (new functionality) and without (existing functionality) and each respond on the next pull request.

I had considered putting the global configuration into an "Advanced" configuration box but decided against it as this is the only Mercurial SCM configuration right now.

I had also considered adding the commit message to the existing MercurialTag bean, but the doc at the top of it suggested its future may not be appropriate for containing the commit message.

I avoided refactoring the MercurialSCM class too much, to make my changes easier to read.  I did have to shift the hg calls to separate methods so I could override them for Testing.  I have good coverage of the new code I added.

I look forward to your feedback.  I saw another request to have similar functionality applied to file names.  Once this feature is accepted, I can pick that one up too.