### PR TITLE
Prevent breaking of dependen plugins

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialTagAction.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialTagAction.java
@@ -1,5 +1,6 @@
 package hudson.plugins.mercurial;
 
+import java.lang.Deprecated;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.scm.SCMRevisionState;
@@ -36,6 +37,11 @@ public class MercurialTagAction extends SCMRevisionState {
     * Branch name of current revision.
     */
     public final String branch;
+    
+    @Deprecated
+    public MercurialTagAction(@NonNull String id, @NonNull String rev, @Nullable String subdir) {
+        this(id, rev, subdir, null);
+    }
 
     public MercurialTagAction(@NonNull String id, @NonNull String rev, @Nullable String subdir, @Nullable String branch) {
         this.id = id;


### PR DESCRIPTION
This change prevents breaking of dependend plugins. 

eg:
https://wiki.jenkins-ci.org/display/JENKINS/Feature+Branch+Notifier+Plugin