### PR TITLE
[FIXED JENKINS-27316] Remove excessive stack traces in log

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
@@ -54,13 +54,19 @@ public class MercurialStatus extends AbstractModelObject implements UnprotectedR
         return "mercurial";
     }
 
+    static private boolean isUnexpandedEnvVar(String str) {
+        return str.startsWith("$");
+    }
+
     static boolean looselyMatches(URI notifyUri, String repository) {
         boolean result = false;
         try {
-            URI repositoryUri = new URI(repository);
-            result = Objects.equal(notifyUri.getHost(), repositoryUri.getHost())
-                && Objects.equal(notifyUri.getPath(), repositoryUri.getPath())
-                && Objects.equal(notifyUri.getQuery(), repositoryUri.getQuery());
+            if (!isUnexpandedEnvVar(repository)) {
+                URI repositoryUri = new URI(repository);
+                result = Objects.equal(notifyUri.getHost(), repositoryUri.getHost())
+                    && Objects.equal(notifyUri.getPath(), repositoryUri.getPath())
+                    && Objects.equal(notifyUri.getQuery(), repositoryUri.getQuery());
+            }
         } catch ( URISyntaxException ex ) {
             LOGGER.log(Level.SEVERE, "could not parse repository uri " + repository, ex);
         }

--- a/src/test/java/hudson/plugins/mercurial/MercurialStatusTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialStatusTest.java
@@ -72,6 +72,9 @@ public class MercurialStatusTest {
       assertTrue( MercurialStatus.looselyMatches(new URI("http://somehost/path"), "ssh://somehost/path") );
       assertTrue( MercurialStatus.looselyMatches(new URI("https://somehost/path"), "http://somehost/path") );
       assertTrue( MercurialStatus.looselyMatches(new URI("ssh://somehost/path"), "https://somehost/path") );
+
+      assertFalse( MercurialStatus.looselyMatches(new URI("http://scm.foocompany.com/hg/foocomponent/"), "${REPO_URL}") );
+      assertFalse( MercurialStatus.looselyMatches(new URI("http://scm.foocompany.com/hg/foocomponent/"), "$REPO_URL") );
   }
   
 }


### PR DESCRIPTION
Using an environment variable in an Mercurial Repo parameter filled the error log with excessive stack traces, in spite of the parameter being valid for passing on to child jobs.