### PR TITLE
[FIXED JENKINS-30120] Branches with space in name failing during changelog

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -655,7 +655,7 @@ public class MercurialSCM extends SCM implements Serializable {
                 ArgumentListBuilder args = hg.seed(false);
                 args.add("log");
                 args.add("--template", MercurialChangeSet.CHANGELOG_TEMPLATE);
-                args.add("--rev", revToBuild + ":0");
+                args.add("--rev", "'" + revToBuild.replace("'", "\\'") + "':0");
                 args.add("--follow");
                 args.add("--prune", prevTag.getId());
                 args.add("--encoding", "UTF-8");


### PR DESCRIPTION
Mercurial changed the format for `--rev`, the branch name must be wrapped in quotes when `:0` is appended.