### PR TITLE
[FIXED JENKINS-30384] Add CrumbExclusion for mercurial hook

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/HgWebHookCrumbExclusion.java
+++ b/src/main/java/hudson/plugins/mercurial/HgWebHookCrumbExclusion.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 aldo.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package hudson.plugins.mercurial;
+
+import hudson.Extension;
+import hudson.security.csrf.CrumbExclusion;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ * @author aldo
+ */
+@Extension
+public class HgWebHookCrumbExclusion extends CrumbExclusion {
+
+    @Override
+    public boolean process(HttpServletRequest req, HttpServletResponse resp, FilterChain chain)
+            throws IOException, ServletException {
+        String pathInfo = req.getPathInfo();
+        if (pathInfo != null && pathInfo.startsWith("/mercurial/notifyCommit")) {
+            chain.doFilter(req, resp);
+            return true;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This allows to trigger a build with a POST request when CSRF protection is enabled