### PR TITLE
[FIXED JENKINS-30120] Fix extra changes being found

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -656,7 +656,6 @@ public class MercurialSCM extends SCM implements Serializable {
                 args.add("log");
                 args.add("--template", MercurialChangeSet.CHANGELOG_TEMPLATE);
                 args.add("--rev", "ancestors('" + revToBuild.replace("'", "\\'") + "') and not ancestors(" + prevTag.getId() + ")");
-                args.add("--follow");
                 args.add("--encoding", "UTF-8");
                 args.add("--encodingmode", "replace");
 

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -655,7 +655,7 @@ public class MercurialSCM extends SCM implements Serializable {
                 ArgumentListBuilder args = hg.seed(false);
                 args.add("log");
                 args.add("--template", MercurialChangeSet.CHANGELOG_TEMPLATE);
-                args.add("--rev", revToBuild + ":0");
+                args.add("--rev", "'" + revToBuild.replace("'", "\\'") + "':0");
                 args.add("--follow");
                 args.add("--prune", prevTag.getId());
                 args.add("--encoding", "UTF-8");

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -655,9 +655,8 @@ public class MercurialSCM extends SCM implements Serializable {
                 ArgumentListBuilder args = hg.seed(false);
                 args.add("log");
                 args.add("--template", MercurialChangeSet.CHANGELOG_TEMPLATE);
-                args.add("--rev", "'" + revToBuild.replace("'", "\\'") + "':0");
+                args.add("--rev", "ancestors('" + revToBuild.replace("'", "\\'") + "') and not ancestors(" + prevTag.getId() + ")");
                 args.add("--follow");
-                args.add("--prune", prevTag.getId());
                 args.add("--encoding", "UTF-8");
                 args.add("--encodingmode", "replace");
 


### PR DESCRIPTION
The current revset query used to grab changes grabs extra changes on large repositories with odd graphs. On our repository with 20000+ commits it is registering 10000+ changes everytime it builds.

I believe this is due to a bug in the revset query used to grab changes. Consider the following graph:

```
@  changeset:   5:2dccdf4acafc
|  branch:      b1
|  tag:         tip
|  parent:      3:c1c5663af0b7
|  summary:     wolo2
|
| o  changeset:   4:939721587c26
| |  branch:      b2
| |  parent:      1:1fd80701afc5
| |  summary:     wolo
| |
o |  changeset:   3:c1c5663af0b7
| |  branch:      b1
| |  summary:     frobnosticate
| |
o |  changeset:   2:a78553b9c3ae
|/    summary:     foobarbaz
|
o  changeset:   1:1fd80701afc5
|  summary:     foobar
|
o  changeset:   0:600d548d0dcb
   summary:     Init
```

This graph is "odd" because rev 3 is a parent of rev 4. Which means when the existing change detection
code runs, it registers 4 as a change:

```
$ hg log --prune a78553b9c3ae --rev '2dccdf4acafc:0' --template '{rev}:{node}\n'
5:2dccdf4acafc73146eac9ba994bcac99105c4a83
4:939721587c260401d99cb598e97b4b4a533698d8
3:c1c5663af0b791671f24ab441da839d836847e4e
```

On this small repository, its not that big of a deal. We get an extra change in the change log, but thats it. On our main very large repository we have started running out of memory during change detection. It also takes roughly 15 minutes to detect changes.

In my experimentation running using `ancestors('$BRANCH_NAME') and not ancestors($LAST_CHANGE_ID)` as the revset and dropping `--prune` will give the intended results.