### PR TITLE
[JENKINS-30295] Implement getCommitId and getTimestamp methods of ChangeLogSet.Entry

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
@@ -2,8 +2,8 @@ package hudson.plugins.mercurial;
 
 import hudson.model.User;
 import hudson.scm.ChangeLogSet;
-import hudson.scm.EditType;
 import hudson.scm.ChangeLogSet.AffectedFile;
+import hudson.scm.EditType;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,15 +83,28 @@ public class MercurialChangeSet extends ChangeLogSet.Entry {
     }
 
     /**
-     * Gets the globally unique changeset ID.  For general purpose use, use {@link #getNode()}.  This method is intended
-     * for use via reflection by the email-ext plugin.
+     * Gets the globally unique changeset ID.  For general purpose use, use {@link #getNode()}.  This method was intended
+     * for use via reflection by the email-ext plugin, but versions 1.40 and later no longer need it.
      */
+    @Deprecated
     public String getRevision() {
         return node;
     }
 
+    @Override
+    public String getCommitId() {
+        return node;
+    }
+
+    @Override
+    public long getTimestamp() {
+        //By default, the String 'date' is in the format '[TIMESTAMP].0[TIMEZONE_OFFSET]' where TIMESTAMP is the number
+        //of seconds (not milliseconds) since the epoch.
+        return Long.parseLong(date.split("\\.")[0]) * 1000;
+    }
+
     /**
-     * Returns the date of the changeset.  Also used via reflection by the email-ext plugin.
+     * Returns the timestamp of the changeset as a string.
      */
     @Exported
     public String getDate() {

--- a/src/test/java/hudson/plugins/mercurial/MercurialRule.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialRule.java
@@ -5,8 +5,8 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Action;
 import hudson.model.FreeStyleBuild;
-import hudson.model.TaskListener;
 import hudson.model.FreeStyleProject;
+import hudson.model.TaskListener;
 import hudson.scm.PollingResult;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.StreamTaskListener;
@@ -18,12 +18,12 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.junit.Assert.*;
 import org.junit.Assume;
 import org.junit.internal.AssumptionViolatedException;
 import org.junit.rules.ExternalResource;
-
 import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.*;
 
 public final class MercurialRule extends ExternalResource {
 
@@ -123,4 +123,9 @@ public final class MercurialRule extends ExternalResource {
         return hgExe().popen(new FilePath(repo), listener, false, new ArgumentListBuilder("log", "-l1", "--template", "{node}"));
     }
 
+    public long getLastChangesetUnixTimestamp(File repo) throws Exception {
+        //hgdate returns the date as a pair of numbers: "1157407993 25200" (Unix timestamp, timezone offset).
+        String date = hgExe().popen(new FilePath(repo), listener, false, new ArgumentListBuilder("log", "-l1", "--template", "{date|hgdate}"));
+        return Long.valueOf(date.split(" ")[0]);
+    }
 }


### PR DESCRIPTION
Newer versions of the email-ext-plugin no longer call getRevision and
getDate by reflection, and call these standard methods instead.

This pull request should fix https://issues.jenkins-ci.org/browse/JENKINS-30295. I hope it's useful to you!