### PR TITLE
Fix regression of commit e9c14f3

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/Cache.java
+++ b/src/main/java/hudson/plugins/mercurial/Cache.java
@@ -163,7 +163,11 @@ class Cache {
         try {
             listener.getLogger().println("Acquired slave node cache lock for node " + node.getNodeName() + ".");            
 
-            FilePath localCaches = rootPath.child("hgcache");
+            final FilePath nodeRootPath = node.getRootPath();
+            if (nodeRootPath == null) {
+                throw new IOException("Cannot retrieve the root directory of the Jenkins node");
+            }
+            FilePath localCaches = nodeRootPath.child("hgcache");
             FilePath localCache = localCaches.child(hash);
             
             // Bundle name is node-specific, as we may have more than one

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -656,9 +656,7 @@ public class MercurialSCM extends SCM implements Serializable {
                 ArgumentListBuilder args = hg.seed(false);
                 args.add("log");
                 args.add("--template", MercurialChangeSet.CHANGELOG_TEMPLATE);
-                args.add("--rev", revToBuild + ":0");
-                args.add("--follow");
-                args.add("--prune", prevTag.getId());
+                args.add("--rev", "ancestors('" + revToBuild.replace("'", "\\'") + "') and not ancestors(" + prevTag.getId() + ")");
                 args.add("--encoding", "UTF-8");
                 args.add("--encodingmode", "replace");
 


### PR DESCRIPTION
In the commit e9c14f3e0bef57891d0114e91b0c9058d056fe61, there is an issue introduced in the hgcache option. Instead of using the node filePath they use the master filePath (rootPath).