### PR TITLE
[JENKINS-34729] Migrate to 2.9 parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.568</version>
+        <version>2.9</version>
     </parent>
     <artifactId>mercurial</artifactId>
     <version>1.55-SNAPSHOT</version>
@@ -13,8 +13,8 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/Mercurial+Plugin</url>
     
     <properties>
-      <findbugs-maven-plugin.version>3.0.1</findbugs-maven-plugin.version>
-      <findbugs.failOnError>true</findbugs.failOnError>
+      <jenkins.version>1.568</jenkins.version>
+      <java.level>6</java.level>
     </properties>
     
     <developers>
@@ -78,11 +78,6 @@
     </pluginRepositories>
     <dependencies>
         <dependency>
-            <groupId>findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <version>1.9.4</version>
@@ -118,27 +113,11 @@
             <artifactId>ini4j</artifactId>
             <version>0.5.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-auth</artifactId>
+            <version>1.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-    <build>
-      <plugins>
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>${findbugs-maven-plugin.version}</version>
-          <configuration>
-            <failOnError>${findbugs.failOnError}</failOnError>
-            <xmlOutput>true</xmlOutput>
-          </configuration>
-          <executions>
-            <execution>
-              <id>run-findbugs</id>
-              <phase>verify</phase> 
-              <goals>
-                <goal>check</goal> 
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </build>
 </project>  

--- a/src/test/java/hudson/plugins/mercurial/MatrixProjectTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MatrixProjectTest.java
@@ -39,8 +39,7 @@ public class MatrixProjectTest {
 
         createPretendSlave("slave_one");
         createPretendSlave("slave_two");
-
-        matrixProject = j.createMatrixProject("matrix_test");
+        matrixProject = j.createProject(MatrixProject.class, "matrix_test");
         matrixProject.setScm(new MercurialSCM(null, repo.getPath(), null, null, null, null, false));
         matrixProject.setAxes(new AxisList(new LabelAxis("label", Arrays.asList("slave_one", "slave_two"))));
 


### PR DESCRIPTION
- Migrate to 2.9 parent pom.
- Fix test - Utility method no longer existing.

@reviewbybees 