### PR TITLE
[JENKINS-23571] Add configuration option for cache directory location

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/Cache.java
+++ b/src/main/java/hudson/plugins/mercurial/Cache.java
@@ -38,7 +38,7 @@ class Cache {
      */
     private final String remote;
 
-    private final String masterCacheRoot;
+    private final @CheckForNull String masterCacheRoot;
 
     private final StandardUsernameCredentials credentials;
 
@@ -62,7 +62,7 @@ class Cache {
 
     private static final Map<String, Cache> CACHES = new HashMap<String, Cache>();
 
-    public synchronized static @NonNull Cache fromURL(String remote, StandardUsernameCredentials credentials, String masterCacheRoot) {
+    public synchronized static @NonNull Cache fromURL(String remote, StandardUsernameCredentials credentials, @CheckForNull String masterCacheRoot) {
         String h = hashSource(remote, credentials, masterCacheRoot);
         Cache cache = CACHES.get(h);
         if (cache == null) {
@@ -81,10 +81,10 @@ class Cache {
         if (lock == null) {
             slaveNodesLocksMap.put(node, lock = new ReentrantLock(true));
         }
-
+    
         return lock;
     }
-
+    
 
     /**
      * Returns a local hg repository cache of the remote repository specified in the given {@link MercurialSCM}
@@ -129,7 +129,7 @@ class Cache {
             try {
 
         // Lock the block used to verify we end up having a cloned repo in the master,
-        // whether if it was previously cloned in a different build or if it's
+        // whether if it was previously cloned in a different build or if it's 
         // going to be cloned right now.
         masterLock.lockInterruptibly();
         try {
@@ -158,20 +158,20 @@ class Cache {
             }
             // Not on master, so need to create/update local cache as well.
 
-        // We are in a slave node that will need also an updated local cache: clone it or
+        // We are in a slave node that will need also an updated local cache: clone it or 
         // pull pending changes, if any. This can be safely done in parallel in
         // different slave nodes for a given repo, so we'll use different
         // node-specific locks to achieve this.
         ReentrantLock slaveNodeLock = getLockForSlaveNode(node.getNodeName());
-
+        
         boolean slaveNodeWasLocked = slaveNodeLock.isLocked();
         if (slaveNodeWasLocked) {
             listener.getLogger().println("Waiting for slave node cache lock in " + node.getNodeName() + " on hgcache/" + hash + " " + slaveNodeWasLocked + "...");
         }
-
+        
         slaveNodeLock.lockInterruptibly();
         try {
-            listener.getLogger().println("Acquired slave node cache lock for node " + node.getNodeName() + ".");
+            listener.getLogger().println("Acquired slave node cache lock for node " + node.getNodeName() + ".");            
 
             final FilePath nodeRootPath = node.getRootPath();
             if (nodeRootPath == null) {
@@ -179,7 +179,7 @@ class Cache {
             }
             FilePath localCaches = nodeRootPath.child("hgcache");
             FilePath localCache = localCaches.child(hash);
-
+            
             // Bundle name is node-specific, as we may have more than one
             // node being updated in parallel, and each one will use its own
             // bundle.
@@ -251,7 +251,7 @@ class Cache {
     /**
      * Hash a URL into a string that only contains characters that are safe as directory names.
      */
-    static String hashSource(String source, StandardUsernameCredentials credentials, String masterCacheRoot) {
+    static String hashSource(String source, StandardUsernameCredentials credentials, @CheckForNull String masterCacheRoot) {
         if (!source.endsWith("/")) {
             source += "/";
         }

--- a/src/main/java/hudson/plugins/mercurial/MercurialInstallation.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialInstallation.java
@@ -64,21 +64,34 @@ public class MercurialInstallation extends ToolInstallation implements
     private String executable;
     private boolean debug;
     private boolean useCaches;
+    private final String masterCacheRoot;
     private boolean useSharing;
     private final String config;
 
+    /** for backwards compatibility */
     @Deprecated
     public MercurialInstallation(String name, String home, String executable,
             boolean debug, boolean useCaches,
             boolean useSharing, List<? extends ToolProperty<?>> properties) {
-        this(name, home, executable, debug, useCaches, useSharing, null, properties);
+        this(name, home, executable, debug, useCaches, null, useSharing, null, properties);
     }
 
-    @DataBoundConstructor public MercurialInstallation(String name, String home, String executable, boolean debug, boolean useCaches, boolean useSharing, String config, List<? extends ToolProperty<?>> properties) {
+    /** for backwards compatibility */
+    @Deprecated
+    public MercurialInstallation(String name, String home, String executable,
+            boolean debug, boolean useCaches,
+            boolean useSharing, String config, List<? extends ToolProperty<?>> properties) {
+        this(name, home, executable, debug, useCaches, null, useSharing, config, properties);
+    }
+
+    @DataBoundConstructor public MercurialInstallation(String name, String home, String executable,
+            boolean debug, boolean useCaches, String masterCacheRoot,
+            boolean useSharing, String config, List<? extends ToolProperty<?>> properties) {
         super(name, home, properties);
         this.executable = Util.fixEmpty(executable);
         this.debug = debug;
         this.useCaches = useCaches || useSharing;
+        this.masterCacheRoot = Util.fixEmptyAndTrim(masterCacheRoot);
         this.config = Util.fixEmptyAndTrim(config);
         this.useSharing = useSharing;
     }
@@ -97,6 +110,10 @@ public class MercurialInstallation extends ToolInstallation implements
 
     public boolean isUseCaches() {
         return useCaches;
+    }
+
+    public String getMasterCacheRoot() {
+        return masterCacheRoot;
     }
 
     public boolean isUseSharing() {

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -960,7 +960,7 @@ public class MercurialSCM extends SCM implements Serializable {
             return null;
         }
         try {
-            FilePath cache = Cache.fromURL(getSource(env), credentials).repositoryCache(inst, node, launcher, listener, useTimeout);
+            FilePath cache = Cache.fromURL(getSource(env), credentials, inst.getMasterCacheRoot()).repositoryCache(inst, node, launcher, listener, useTimeout);
             if (cache != null) {
                 return new CachedRepo(cache.getRemote(), inst.isUseSharing());
             } else {

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -112,7 +112,7 @@ public final class MercurialSCMSource extends SCMSource {
         }
         Launcher launcher = node.createLauncher(listener);
         StandardUsernameCredentials credentials = getCredentials();
-        FilePath cache = Cache.fromURL(source, credentials).repositoryCache(inst, node, launcher, listener, true);
+        FilePath cache = Cache.fromURL(source, credentials, inst.getMasterCacheRoot()).repositoryCache(inst, node, launcher, listener, true);
         if (cache == null) {
             listener.error("Could not use caches, not fetching branch heads");
             return;

--- a/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
@@ -12,6 +12,9 @@
   <f:entry field="useCaches" title="${%Use Repository Caches}">
     <f:checkbox/>
   </f:entry>
+  <f:entry field="masterCacheRoot" title="${%Master cache directory}">
+    <f:textbox/>
+  </f:entry>
   <f:entry field="useSharing" title="${%Use Repository Sharing}">
     <f:checkbox/>
   </f:entry>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/help-masterCacheRoot.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/help-masterCacheRoot.html
@@ -1,0 +1,4 @@
+<div>
+    Location of cached repositories on the master node.
+    Default : $JENKINS_HOME/hgcache
+</div>

--- a/src/test/java/hudson/plugins/mercurial/CacheTest.java
+++ b/src/test/java/hudson/plugins/mercurial/CacheTest.java
@@ -11,17 +11,19 @@ import org.jvnet.hudson.test.Bug;
 public class CacheTest {
 
     @Test public void hashSource() throws Exception {
-        assertEquals("5439A9B4063BB8F4885037E71B5079E1913DB6CA-core-main", Cache.hashSource("http://hg.netbeans.org/core-main/", null));
-        assertEquals("5439A9B4063BB8F4885037E71B5079E1913DB6CA-core-main", Cache.hashSource("http://hg.netbeans.org/core-main", null));
-        assertEquals("5731708C5EEAF9F1320B57D5F6A21E85EA5ADF2D-project", Cache.hashSource("ssh://dude@math.utexas.edu/some/project/", null));
-        assertEquals("210ED9E2610F74A473985D8D9EF4483D5D30265E-project", Cache.hashSource("ssh://dudette@math.utexas.edu/some/project/", null));
+        assertEquals("5439A9B4063BB8F4885037E71B5079E1913DB6CA-core-main", Cache.hashSource("http://hg.netbeans.org/core-main/", null, null));
+        assertEquals("5439A9B4063BB8F4885037E71B5079E1913DB6CA-core-main", Cache.hashSource("http://hg.netbeans.org/core-main", null, null));
+        assertEquals("5731708C5EEAF9F1320B57D5F6A21E85EA5ADF2D-project", Cache.hashSource("ssh://dude@math.utexas.edu/some/project/", null, null));
+        assertEquals("210ED9E2610F74A473985D8D9EF4483D5D30265E-project", Cache.hashSource("ssh://dudette@math.utexas.edu/some/project/", null, null));
+        assertEquals("D3D58986EB0F726F38EE6393B1DB943C0BAD0B4D-project", Cache.hashSource("ssh://dudette@math.utexas.edu/some/project/", null, "/var/tmp/hgcache"));
         // Cannot use UsernamePasswordCredentialsImpl from a unit test, since it tries to actually decrypt the password, which requires Jenkins.instance.
-        assertEquals("0D1FD823FDA2F7144C463007FEAF9F824333B3D2-core-main-bob-at-nowhere.net", Cache.hashSource("http://hg.netbeans.org/core-main/", new MockUsernamePasswordCredentials(CredentialsScope.GLOBAL, "what-ever", "bob@nowhere.net")));
+        assertEquals("0D1FD823FDA2F7144C463007FEAF9F824333B3D2-core-main-bob-at-nowhere.net",
+				Cache.hashSource("http://hg.netbeans.org/core-main/", new MockUsernamePasswordCredentials(CredentialsScope.GLOBAL, "what-ever", "bob@nowhere.net"),null));
     }
 
     @Bug(12544)
     @Test public void hashSource2() throws Exception {
-        assertEquals("DA7E6A4632009859A61A551999EE2109EBB69267-ronaldradial", Cache.hashSource("http://ronaldradial:8000/", null));
+        assertEquals("DA7E6A4632009859A61A551999EE2109EBB69267-ronaldradial", Cache.hashSource("http://ronaldradial:8000/", null,null));
     }
 
     private static class MockUsernamePasswordCredentials extends BaseStandardCredentials implements StandardUsernamePasswordCredentials {

--- a/src/test/java/hudson/plugins/mercurial/CachingCustomDirSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/CachingCustomDirSCMTest.java
@@ -1,7 +1,6 @@
 package hudson.plugins.mercurial;
 
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
@@ -33,7 +32,7 @@ public class CachingCustomDirSCMTest {
 		j.jenkins
 				.getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
 				.setInstallations(new MercurialInstallation(CACHING_INSTALLATION, "", "hg",
-						false, true, Paths.get("target", "test-data", "custom-cache-dir").toString(), false, "",
+						false, true, new File(tmp.newFolder(),"custom-cache-dir").getAbsolutePath().toString(), false, "",
 						Collections.<ToolProperty<?>> emptyList()));
 	}
 

--- a/src/test/java/hudson/plugins/mercurial/CachingCustomDirSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/CachingCustomDirSCMTest.java
@@ -1,0 +1,53 @@
+package hudson.plugins.mercurial;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.regex.Pattern;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.model.FreeStyleProject;
+import hudson.tools.ToolProperty;
+
+public class CachingCustomDirSCMTest {
+
+	@Rule
+	public JenkinsRule j = new JenkinsRule();
+	@Rule
+	public MercurialRule m = new MercurialRule(j);
+	@Rule
+	public TemporaryFolder tmp = new TemporaryFolder();
+	private File repo;
+
+	private static final String CACHING_INSTALLATION = "caching-custom-dir";
+
+	@Before
+	public void setUp() throws Exception {
+		repo = tmp.getRoot();
+		j.jenkins
+				.getDescriptorByType(MercurialInstallation.DescriptorImpl.class)
+				.setInstallations(new MercurialInstallation(CACHING_INSTALLATION, "", "hg",
+						false, true, Paths.get("target", "test-data", "custom-cache-dir").toString(), false, "",
+						Collections.<ToolProperty<?>> emptyList()));
+	}
+
+	@Test
+	public void customCacheLocationFromSlave() throws Exception {
+		FreeStyleProject p = j.createFreeStyleProject();
+		p.setScm(new MercurialSCM(CACHING_INSTALLATION, repo.getPath(), null, null,
+				null, null, false));
+		p.setAssignedNode(j.createOnlineSlave());
+		m.hg(repo, "init");
+		m.touchAndCommit(repo, "a");
+		String log = m.buildAndCheck(p, "a");
+		Pattern pattern = Pattern.compile("hg clone .*custom-cache-dir");
+		Assert.assertTrue(pattern.matcher(log).find());
+	}
+
+}


### PR DESCRIPTION
[JENKINS-23571](https://issues.jenkins-ci.org/browse/JENKINS-23571)

This PR adds a new optional configuration option for "mercurial installations".

This new options allows users to customize the location of cached mercurial repositories on the jenkins master node when using repository caching. The default value remains unchanged ($JENKINS_HOME/hgcache)

This feature is useful for people who want to place this cache outside of $JENKINS_HOME.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jenkinsci/mercurial-plugin/91)
<!-- Reviewable:end -->
