### PR TITLE
PCT fixes: Use ParametersDefinitionProperty

### DIFF
--- a/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
+++ b/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
@@ -319,8 +319,8 @@ public abstract class SCMTestBase {
         FreeStyleProject p = j.createFreeStyleProject();
         p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(), "${BRANCH}",
                 null, null, null, false));
-        // This is not how a real parameterized build runs, but using
-        // ParametersDefinitionProperty just looks untestable:
+        // SECURITY-170 - have to use ParametersDefinitionProperty
+        p.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("BRANCH", "b")));
         String log = m.buildAndCheck(p, "variant", new ParametersAction(
                 new StringParameterValue("BRANCH", "b")));
         assertTrue(log, log.contains("--rev b"));


### PR DESCRIPTION
With the new changes to the plugin compatibility tester, a few of this plugin's tests fail, all implementing `SCMTestBase`. Currently, it isn't using `ParametersDefinitionProperty` to define parameters in one of the pipeline jobs. SECURITY-170 required some behavior changes upon the Jenkins 2.x release & the plugin compat tester can run against more recent versions, the tests are failing even though there are really no issues. I have run all the mercurial tests using `mvn test` as well as through the plugin compat tester, and there are now no errors.

I saw there were some comments about using `ParametersDefinitionProperty` at the point of change.  However, we basically have to do it at this point to run tests against the post `SECURITY-170` versions of Jenkins.

@reviewbybees