### PR TITLE
[JENKINS-43507] Allow SCMSource and SCMNavigator subtypes to share common traits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
-    <version>1.61-SNAPSHOT</version>
+  <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Mercurial plugin</name>
     <description>Allows Jenkins to check out projects from the Mercurial SCM.</description>
@@ -176,4 +176,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-</project>  
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>2.0</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.8</version>
+            <version>1.9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
-    <version>2.0-alpha-4</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Mercurial plugin</name>
     <description>Allows Jenkins to check out projects from the Mercurial SCM.</description>
@@ -56,7 +56,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>mercurial-2.0-alpha-4</tag>
+      <tag>HEAD</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
       <jenkins.version>1.642.3</jenkins.version>
       <no-test-jar>false</no-test-jar>
-      <scm-api-plugin.version>2.2.0-20170615.114844-13</scm-api-plugin.version>
+      <scm-api-plugin.version>2.2.0-alpha-1</scm-api-plugin.version>
     </properties>
     
     <developers>
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.11-alpha-1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
       <jenkins.version>1.642.3</jenkins.version>
       <no-test-jar>false</no-test-jar>  
-      <scm-api-plugin.version>2.2.0-20170612.200107-11</scm-api-plugin.version>
+      <scm-api-plugin.version>2.2.0-20170615.114844-13</scm-api-plugin.version>
     </properties>
     
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0-alpha-4</version>
     <packaging>hpi</packaging>
     <name>Jenkins Mercurial plugin</name>
     <description>Allows Jenkins to check out projects from the Mercurial SCM.</description>
@@ -56,7 +56,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>mercurial-2.0-alpha-4</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
       <jenkins.version>1.642.3</jenkins.version>
       <no-test-jar>false</no-test-jar>  
-      <scm-api-plugin.version>2.2.0-20170504.132618-8</scm-api-plugin.version>
+      <scm-api-plugin.version>2.2.0-20170612.200107-11</scm-api-plugin.version>
     </properties>
     
     <developers>
@@ -70,7 +70,16 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+  <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>scm-api</artifactId>
+        <version>${scm-api-plugin.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,15 +70,6 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>scm-api</artifactId>
-                <version>${scm-api-plugin.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
-    <version>2.0-alpha-1</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Mercurial plugin</name>
     <description>Allows Jenkins to check out projects from the Mercurial SCM.</description>
@@ -56,7 +56,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>mercurial-2.0-alpha-1</tag>
+      <tag>HEAD</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
   <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.8</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
             <version>2.1.10</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.0-alpha-1</version>
     <packaging>hpi</packaging>
     <name>Jenkins Mercurial plugin</name>
     <description>Allows Jenkins to check out projects from the Mercurial SCM.</description>
@@ -56,7 +56,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>mercurial-2.0-alpha-1</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
     
     <properties>
       <jenkins.version>1.642.3</jenkins.version>
-      <scm-api-plugin.version>2.1.0</scm-api-plugin.version>
+      <no-test-jar>false</no-test-jar>  
+      <scm-api-plugin.version>2.2.0-20170504.132618-8</scm-api-plugin.version>
     </properties>
     
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
-  <version>2.0-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Jenkins Mercurial plugin</name>
     <description>Allows Jenkins to check out projects from the Mercurial SCM.</description>

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 package hudson.plugins.mercurial;
 
 import com.cloudbees.plugins.credentials.common.IdCredentials;

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
@@ -1,0 +1,100 @@
+package hudson.plugins.mercurial;
+
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import hudson.plugins.mercurial.browser.HgBrowser;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.trait.SCMBuilder;
+
+public class MercurialSCMBuilder<B extends MercurialSCMBuilder<B>> extends SCMBuilder<B, MercurialSCM> {
+    /**
+     * The browser to use or {@code null} to use the "auto" browser.
+     */
+    private @CheckForNull HgBrowser browser;
+    /**
+     * {@code true} to clean local modifications and untracked files.
+     */
+    private boolean clean;
+    /**
+     * The {@link IdCredentials#getId()} of the credentials to use or {@code null} to use none / the installation
+     * defaults.
+     */
+    private @CheckForNull String credentialsId;
+    /**
+     * The {@link MercurialInstallation#getName()}.
+     */
+    private @CheckForNull String installation;
+    /**
+     * The repository to track. This can be URL or a local file path.
+     */
+    private final @Nonnull String source;
+
+    public MercurialSCMBuilder(@Nonnull SCMHead head, @CheckForNull SCMRevision revision, String source,
+                               String credentialsId) {
+        super(MercurialSCM.class, head, revision);
+        this.source = source;
+        this.credentialsId = credentialsId;
+    }
+
+    public final HgBrowser browser() {
+        return browser;
+    }
+
+    public final boolean clean() {
+        return clean;
+    }
+
+    public final String credentialsId() {
+        return credentialsId;
+    }
+
+    public final String installation() {
+        return installation;
+    }
+
+    public final String source() {
+        return source;
+    }
+
+    @SuppressWarnings("unchecked") public @Nonnull B withBrowser(HgBrowser browser) {
+        this.browser = browser;
+        return (B) this;
+    }
+
+    @SuppressWarnings("unchecked") public @Nonnull B withClean(boolean clean) {
+        this.clean = clean;
+        return (B) this;
+    }
+
+    @SuppressWarnings("unchecked") public @Nonnull B withCredentialsId(String credentialsId) {
+        this.credentialsId = credentialsId;
+        return (B) this;
+    }
+
+    @SuppressWarnings("unchecked") public @Nonnull B withInstallation(String installation) {
+        this.installation = installation;
+        return (B) this;
+    }
+
+    @Override public @Nonnull MercurialSCM build() {
+        String rev = revision() instanceof MercurialSCMSource.MercurialRevision
+                ? ((MercurialSCMSource.MercurialRevision) revision()).getHash()
+                : head().getName();
+        MercurialSCM result = new MercurialSCM(source());
+        if (revision() instanceof MercurialSCMSource.MercurialRevision) {
+            result.setRevisionType(MercurialSCM.RevisionType.CHANGESET);
+            result.setRevision(((MercurialSCMSource.MercurialRevision) revision()).getHash());
+        } else {
+            result.setRevisionType(MercurialSCM.RevisionType.BRANCH);
+            result.setRevision(head().getName());
+        }
+        result.setBrowser(browser());
+        result.setClean(clean());
+        result.setCredentialsId(credentialsId());
+        result.setInstallation(installation());
+        result.setDisableChangeLog(false);
+        return result;
+    }
+}

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
@@ -29,7 +29,8 @@ public class MercurialSCMBuilder<B extends MercurialSCMBuilder<B>> extends SCMBu
     /**
      * The repository to track. This can be URL or a local file path.
      */
-    private final @Nonnull String source;
+    private @Nonnull
+    String source;
 
     public MercurialSCMBuilder(@Nonnull SCMHead head, @CheckForNull SCMRevision revision, String source,
                                String credentialsId) {
@@ -78,14 +79,19 @@ public class MercurialSCMBuilder<B extends MercurialSCMBuilder<B>> extends SCMBu
         return (B) this;
     }
 
+    @SuppressWarnings("unchecked")
+    public @Nonnull
+    B withSource(String source) {
+        this.source = source;
+        return (B) this;
+    }
+
     @Override public @Nonnull MercurialSCM build() {
-        String rev = revision() instanceof MercurialSCMSource.MercurialRevision
-                ? ((MercurialSCMSource.MercurialRevision) revision()).getHash()
-                : head().getName();
+        SCMRevision revision = revision();
         MercurialSCM result = new MercurialSCM(source());
-        if (revision() instanceof MercurialSCMSource.MercurialRevision) {
+        if (revision instanceof MercurialSCMSource.MercurialRevision) {
             result.setRevisionType(MercurialSCM.RevisionType.CHANGESET);
-            result.setRevision(((MercurialSCMSource.MercurialRevision) revision()).getHash());
+            result.setRevision(((MercurialSCMSource.MercurialRevision) revision).getHash());
         } else {
             result.setRevisionType(MercurialSCM.RevisionType.BRANCH);
             result.setRevision(head().getName());

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
@@ -29,11 +29,10 @@ public class MercurialSCMBuilder<B extends MercurialSCMBuilder<B>> extends SCMBu
     /**
      * The repository to track. This can be URL or a local file path.
      */
-    private @Nonnull
-    String source;
+    private @Nonnull String source;
 
-    public MercurialSCMBuilder(@Nonnull SCMHead head, @CheckForNull SCMRevision revision, String source,
-                               String credentialsId) {
+    public MercurialSCMBuilder(@Nonnull SCMHead head, @CheckForNull SCMRevision revision, @Nonnull String source,
+                               @CheckForNull String credentialsId) {
         super(MercurialSCM.class, head, revision);
         this.source = source;
         this.credentialsId = credentialsId;

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -77,10 +77,15 @@ public final class MercurialSCMSource extends SCMSource {
     @Deprecated @Restricted(NoExternalUse.class) @RestrictedSince("2.0") private transient boolean clean;
 
     @DataBoundConstructor
-    public MercurialSCMSource(String id, String source) {
-        super(id);
+    public MercurialSCMSource(String source) {
         this.source = source;
         this.traits = new ArrayList<>();
+    }
+
+    @Deprecated
+    public MercurialSCMSource(String id, String source) {
+        this(source);
+        setId(id);
     }
 
     @Deprecated @Restricted(NoExternalUse.class) @RestrictedSince("2.0") public MercurialSCMSource(

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -53,8 +53,12 @@ import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.api.trait.SCMTraitDescriptor;
+import jenkins.scm.impl.form.NamedArrayList;
+import jenkins.scm.impl.trait.Discovery;
 import jenkins.scm.impl.trait.RegexSCMHeadFilterTrait;
 import jenkins.scm.impl.trait.RegexSCMSourceFilterTrait;
+import jenkins.scm.impl.trait.Selection;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -389,11 +393,20 @@ public final class MercurialSCMSource extends SCMSource {
             return RepositoryBrowsers.filter(HgBrowser.class);
         }
 
-        public List<SCMSourceTraitDescriptor> getTraitDescriptors() {
-            return SCMSourceTrait._for(this, MercurialSCMSourceContext.class, MercurialSCMBuilder.class);
+        public List<NamedArrayList<? extends SCMTraitDescriptor<?>>> getTraitsDescriptorLists() {
+            List<SCMSourceTraitDescriptor> all =
+                    SCMSourceTrait._for(this, MercurialSCMSourceContext.class, MercurialSCMBuilder.class);
+            List<NamedArrayList<? extends SCMTraitDescriptor<?>>> result = new ArrayList<>();
+            NamedArrayList.select(all, "Within repository",
+                    NamedArrayList.anyOf(
+                            NamedArrayList.withAnnotation(Discovery.class),
+                                    NamedArrayList.withAnnotation(Selection.class)
+                    ),true, result);
+            NamedArrayList.select(all, "Additional", null, true, result);
+            return result;
         }
 
-        public List<SCMSourceTrait> getTraitDefaults() {
+        public List<SCMSourceTrait> getTraitsDefaults() {
             return Collections.emptyList();
         }
 

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -237,8 +237,7 @@ public final class MercurialSCMSource extends SCMSource {
                             }, new SCMSourceRequest.ProbeLambda<SCMHead, MercurialRevision>() {
                                 @Override
                                 public @Nonnull
-                                SCMSourceCriteria.Probe create(@Nonnull SCMHead branch, @Nullable final
-                                MercurialRevision revision) {
+                                SCMSourceCriteria.Probe create(@Nonnull SCMHead branch, @Nullable final MercurialRevision revision) {
                                     return new SCMProbeImpl(hg, cache, listener, revision, name);
                                 }
                             }, new SCMSourceRequest.Witness() {
@@ -366,8 +365,8 @@ public final class MercurialSCMSource extends SCMSource {
                     .withAll(availableCredentials(owner, source));
         }
 
-        private boolean hasAccessToCredentialsMetadata(SCMSourceOwner owner) {
-            if (owner == null) {
+        private boolean hasAccessToCredentialsMetadata(SCMSourceOwner owner){
+            if (owner == null){
                 return Jenkins.getActiveInstance().hasPermission(Jenkins.ADMINISTER);
             }
             return owner.hasPermission(Item.EXTENDED_READ);

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -54,6 +54,7 @@ import jenkins.scm.api.trait.SCMSourceRequest;
 import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import jenkins.scm.impl.trait.RegexSCMHeadFilterTrait;
+import jenkins.scm.impl.trait.RegexSCMSourceFilterTrait;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
@@ -154,21 +155,13 @@ public final class MercurialSCMSource extends SCMSource {
     }
 
     @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public String getInstallation() {
-        for (SCMSourceTrait t: traits) {
-            if (t instanceof MercurialInstallationSCMSourceTrait) {
-                return ((MercurialInstallationSCMSourceTrait) t).getInstallation();
-            }
-        }
-        return null;
+        MercurialInstallationSCMSourceTrait t = getTrait(MercurialInstallationSCMSourceTrait.class);
+        return t != null ? t.getInstallation() : null;
     }
 
     @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public String getBranchPattern() {
-        for (SCMSourceTrait t: traits) {
-            if (t instanceof RegexSCMHeadFilterTrait) {
-                return ((RegexSCMHeadFilterTrait) t).getRegex();
-            }
-        }
-        return "";
+        RegexSCMHeadFilterTrait t = getTrait(RegexSCMHeadFilterTrait.class);
+        return t != null ? t.getRegex() : "";
     }
 
     @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public String getModules() {
@@ -180,21 +173,21 @@ public final class MercurialSCMSource extends SCMSource {
     }
 
     @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public HgBrowser getBrowser() {
-        for (SCMSourceTrait t: traits) {
-            if (t instanceof MercurialBrowserSCMSourceTrait) {
-                return ((MercurialBrowserSCMSourceTrait) t).getBrowser();
-            }
-        }
-        return null;
+        MercurialBrowserSCMSourceTrait t = getTrait(MercurialBrowserSCMSourceTrait.class);
+        return t != null ? t.getBrowser() : null;
     }
 
     @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public boolean isClean() {
+        return getTrait(CleanMercurialSCMSourceTrait.class) != null;
+    }
+
+    private @CheckForNull <T extends SCMSourceTrait> T getTrait(@Nonnull Class<T> traitClass) {
         for (SCMSourceTrait t: traits) {
-            if (t instanceof CleanMercurialSCMSourceTrait) {
-                return true;
+            if (traitClass.isInstance(t)) {
+                return traitClass.cast(t);
             }
         }
-        return false;
+        return null;
     }
 
     @Override protected void retrieve(@CheckForNull SCMSourceCriteria criteria, @Nonnull SCMHeadObserver observer,

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -278,22 +278,22 @@ public final class MercurialSCMSource extends SCMSource {
     @CheckForNull
     protected SCMRevision retrieve(@NonNull String thingName, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
-        try (MercurialSCMSourceRequest request = new MercurialSCMSourceContext<>(criteria, observer)
+        try (MercurialSCMSourceRequest request = new MercurialSCMSourceContext<>(null, SCMHeadObserver.none())
                 .withTraits(traits)
                 .newRequest(this, listener)) {
             MercurialInstallation inst = MercurialSCM.findInstallation(request.installation());
             if (inst == null) {
                 listener.error("No configured Mercurial installation");
-                return;
+                return null;
             }
             if (!inst.isUseCaches()) {
                 listener.error("Mercurial installation " + request.installation() + " does not support caches");
-                return;
+                return null;
             }
             final Node node = Jenkins.getInstance();
             if (node == null) { // Should not happen BTW
                 listener.error("Cannot retrieve the Jenkins master node");
-                return;
+                return null;
             }
             Launcher launcher = node.createLauncher(listener);
             StandardUsernameCredentials credentials = getCredentials(request.credentialsId());

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -5,11 +5,12 @@ import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
+import hudson.RestrictedSince;
 import hudson.Util;
 import hudson.model.Action;
 import hudson.model.Descriptor;
@@ -17,19 +18,24 @@ import hudson.model.Item;
 import hudson.model.Node;
 import hudson.model.TaskListener;
 import hudson.plugins.mercurial.browser.HgBrowser;
+import hudson.plugins.mercurial.traits.CleanMercurialSCMSourceTrait;
+import hudson.plugins.mercurial.traits.MercurialBrowserSCMSourceTrait;
+import hudson.plugins.mercurial.traits.MercurialInstallationSCMSourceTrait;
 import hudson.scm.RepositoryBrowser;
 import hudson.scm.RepositoryBrowsers;
 import hudson.scm.SCM;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import hudson.util.VersionNumber;
 import java.io.IOException;
+import java.io.ObjectStreamException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMHead;
@@ -43,160 +49,265 @@ import jenkins.scm.api.SCMSourceCriteria;
 import jenkins.scm.api.SCMSourceDescriptor;
 import jenkins.scm.api.SCMSourceOwner;
 import jenkins.scm.api.metadata.PrimaryInstanceMetadataAction;
+import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.trait.RegexSCMHeadFilterTrait;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
 public final class MercurialSCMSource extends SCMSource {
 
-    private final String installation;
-    private final String source;
-    private final String credentialsId;
-    private final String branchPattern;
-    private final String modules;
-    private final String subdir;
-    private final HgBrowser browser;
-    private final boolean clean;
+    private final @Nonnull String source;
+    private final @CheckForNull String credentialsId;
+    private @Nonnull List<SCMSourceTrait> traits;
+    @Deprecated @Restricted(NoExternalUse.class) @RestrictedSince("2.0") private transient String installation;
+    @Deprecated @Restricted(NoExternalUse.class) @RestrictedSince("2.0") private transient String branchPattern;
+    // USELESS FIELD REMOVED: private final String modules;
+    // USELESS FIELD REMOVED: private final String subdir;
+    @Deprecated @Restricted(NoExternalUse.class) @RestrictedSince("2.0") private transient HgBrowser browser;
+    @Deprecated @Restricted(NoExternalUse.class) @RestrictedSince("2.0") private transient boolean clean;
 
     @DataBoundConstructor
-    public MercurialSCMSource(String id, String installation, String source, String credentialsId, String branchPattern, String modules, String subdir, HgBrowser browser, boolean clean) {
+    public MercurialSCMSource(String id, String source, String credentialsId) {
         super(id);
-        this.installation = installation;
         this.source = source;
         this.credentialsId = credentialsId;
-        this.branchPattern = branchPattern;
-        this.modules = modules;
-        this.subdir = subdir;
-        this.browser = browser;
-        this.clean = clean;
-    }
-    
-    public String getInstallation() {
-        return installation;
+        this.traits = new ArrayList<>();
     }
 
-    public String getSource() {
+    @Deprecated @Restricted(NoExternalUse.class) @RestrictedSince("2.0") public MercurialSCMSource(
+            String id, String installation, String source, String credentialsId, String branchPattern, String modules,
+            String subdir, HgBrowser browser, boolean clean) {
+        super(id);
+        this.source = source;
+        this.credentialsId = credentialsId;
+        this.traits = new ArrayList<>();
+        if (StringUtils.isNotBlank(branchPattern) && !".*".equals(branchPattern) && !".+".equals(branchPattern)) {
+            traits.add(new RegexSCMHeadFilterTrait(branchPattern));
+        }
+        if (clean) {
+            traits.add(new CleanMercurialSCMSourceTrait());
+        }
+        if (installation != null) {
+            traits.add(new MercurialInstallationSCMSourceTrait(installation));
+        }
+        if (browser != null) {
+            traits.add(new MercurialBrowserSCMSourceTrait(browser));
+        }
+    }
+
+    @SuppressWarnings({"deprecation", "ConstantConditions"}) private Object readResolve() throws ObjectStreamException {
+        if (traits == null) {
+            traits = new ArrayList<>();
+            if (branchPattern != null) {
+                if (StringUtils.isNotBlank(branchPattern) && !".*".equals(branchPattern) && !".+"
+                        .equals(branchPattern)) {
+                    traits.add(new RegexSCMHeadFilterTrait(branchPattern));
+                }
+            }
+            if (clean) {
+                traits.add(new CleanMercurialSCMSourceTrait());
+            }
+            if (installation != null) {
+                traits.add(new MercurialInstallationSCMSourceTrait(installation));
+            }
+            if (browser != null) {
+                traits.add(new MercurialBrowserSCMSourceTrait(browser));
+            }
+        }
+        return this;
+    }
+
+    public @Nonnull String getSource() {
         return source;
     }
 
-    public String getCredentialsId() {
+    public @Nonnull List<SCMSourceTrait> getTraits() {
+        return Collections.unmodifiableList(traits);
+    }
+
+    public @CheckForNull String getCredentialsId() {
         return credentialsId;
     }
 
-    public String getBranchPattern() {
-        return branchPattern;
+    @DataBoundSetter public void setTraits(@CheckForNull List<SCMSourceTrait> traits) {
+        this.traits = new ArrayList<>(Util.fixNull(traits));
     }
 
-    public String getModules() {
-        return modules;
-    }
-
-    public String getSubdir() {
-        return subdir;
-    }
-
-    public HgBrowser getBrowser() {
-        // Could default to HgWeb the way MercurialSCM does, but probably unnecessary.
-        return browser;
-    }
-
-    public boolean isClean() {
-        return clean;
-    }
-
-    @Override
-    protected void retrieve(@edu.umd.cs.findbugs.annotations.CheckForNull SCMSourceCriteria criteria,
-                            @NonNull SCMHeadObserver observer,
-                            @edu.umd.cs.findbugs.annotations.CheckForNull SCMHeadEvent<?> event,
-                            @NonNull final TaskListener listener) throws IOException, InterruptedException {
-        MercurialInstallation inst = MercurialSCM.findInstallation(installation);
-        if (inst == null) {
-            listener.error("No configured Mercurial installation");
-            return;
-        }
-        if (!inst.isUseCaches()) {
-            listener.error("Mercurial installation " + installation + " does not support caches");
-            return;
-        }
-        final Node node = Jenkins.getInstance();
-        if (node == null) { // Should not happen BTW
-            listener.error("Cannot retrieve the Jenkins master node");
-            return;
-        }
-        Launcher launcher = node.createLauncher(listener);
-        StandardUsernameCredentials credentials = getCredentials();
-        final FilePath cache = Cache.fromURL(source, credentials, inst.getMasterCacheRoot()).repositoryCache(inst, node, launcher, listener, true);
-        if (cache == null) {
-            listener.error("Could not use caches, not fetching branch heads");
-            return;
-        }
-        final HgExe hg = new HgExe(inst, credentials, launcher, node, listener, new EnvVars());
-        try {
-            String heads = hg.popen(cache, listener, true, new ArgumentListBuilder("heads", "--template", "{node} {branch}\\n"));
-            Pattern p = Pattern.compile(Util.fixNull(branchPattern).length() == 0 ? ".+" : branchPattern);
-            for (String line : heads.split("\r?\n")) {
-                final String[] nodeBranch = line.split(" ", 2);
-                final String name = nodeBranch[1];
-                if (p.matcher(name).matches()) {
-                    listener.getLogger().println("Found branch " + name);
-                    SCMHead branch = new SCMHead(name);
-                    if (criteria != null) {
-                        SCMProbe probe = new SCMProbe() {
-                            @NonNull
-                            @Override
-                            public SCMProbeStat stat(@NonNull String path) throws IOException {
-                                try {
-                                    String files = hg.popen(cache, listener, true,
-                                            new ArgumentListBuilder("locate", "-r", nodeBranch[0], "-I", "path:" + path));
-                                    if (StringUtils.isBlank(files)) {
-                                        return SCMProbeStat.fromType(SCMFile.Type.NONEXISTENT);
-                                    }
-                                    return SCMProbeStat.fromType(SCMFile.Type.REGULAR_FILE);
-                                } catch (InterruptedException e) {
-                                    throw new IOException(e);
-                                }
-                            }
-
-                            @Override
-                            public void close() throws IOException {
-
-                            }
-
-                            @Override
-                            public String name() {
-                                return name;
-                            }
-
-                            @Override
-                            public long lastModified() {
-                                return 0;
-                            }
-                        };
-                        if (criteria.isHead(probe, listener)) {
-                            listener.getLogger().println("Met criteria");
-                        } else {
-                            listener.getLogger().println("Does not meet criteria");
-                            continue;
-                        }
-                    }
-                    observer.observe(branch, new MercurialRevision(branch, nodeBranch[0]));
-                } else {
-                    listener.getLogger().println("Ignoring branch " + name);
-                }
+    @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public String getInstallation() {
+        for (SCMSourceTrait t: traits) {
+            if (t instanceof MercurialInstallationSCMSourceTrait) {
+                return ((MercurialInstallationSCMSourceTrait) t).getInstallation();
             }
-        } finally {
-            hg.close();
+        }
+        return null;
+    }
+
+    @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public String getBranchPattern() {
+        for (SCMSourceTrait t: traits) {
+            if (t instanceof RegexSCMHeadFilterTrait) {
+                return ((RegexSCMHeadFilterTrait) t).getRegex();
+            }
+        }
+        return "";
+    }
+
+    @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public String getModules() {
+        return "";
+    }
+
+    @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public String getSubdir() {
+        return "";
+    }
+
+    @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public HgBrowser getBrowser() {
+        for (SCMSourceTrait t: traits) {
+            if (t instanceof MercurialBrowserSCMSourceTrait) {
+                return ((MercurialBrowserSCMSourceTrait) t).getBrowser();
+            }
+        }
+        return null;
+    }
+
+    @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public boolean isClean() {
+        for (SCMSourceTrait t: traits) {
+            if (t instanceof CleanMercurialSCMSourceTrait) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override protected void retrieve(@CheckForNull SCMSourceCriteria criteria, @Nonnull SCMHeadObserver observer,
+                            @CheckForNull SCMHeadEvent<?> event, @Nonnull final TaskListener listener)
+            throws IOException, InterruptedException {
+        try (MercurialSCMSourceRequest request= new MercurialSCMSourceContext<>(criteria, observer)
+                .withTraits(traits)
+                .newRequest(this, listener) ) {
+            MercurialInstallation inst = MercurialSCM.findInstallation(request.installation());
+            if (inst == null) {
+                listener.error("No configured Mercurial installation");
+                return;
+            }
+            if (!inst.isUseCaches()) {
+                listener.error("Mercurial installation " + request.installation() + " does not support caches");
+                return;
+            }
+            final Node node = Jenkins.getInstance();
+            if (node == null) { // Should not happen BTW
+                listener.error("Cannot retrieve the Jenkins master node");
+                return;
+            }
+            Launcher launcher = node.createLauncher(listener);
+            StandardUsernameCredentials credentials = getCredentials(request.credentialsId());
+            final FilePath cache = Cache.fromURL(request.source(), credentials, inst.getMasterCacheRoot())
+                    .repositoryCache(inst, node, launcher, listener, true);
+            if (cache == null) {
+                listener.error("Could not use caches, not fetching branch heads");
+                return;
+            }
+            final HgExe hg = new HgExe(inst, credentials, launcher, node, listener, new EnvVars());
+            try {
+                String heads = hg.popen(cache, listener, true,
+                        new ArgumentListBuilder("heads", "--template", "{node} {branch}\\n"));
+                int count = 0;
+                for (String line : heads.split("\r?\n")) {
+                    final String[] nodeBranch = line.split(" ", 2);
+                    final String name = nodeBranch[1];
+                    count++;
+                    if (request.process(new SCMHead(name),
+                            new SCMSourceRequest.RevisionLambda<SCMHead, MercurialRevision>() {
+                                @Override
+                                public @Nonnull
+                                MercurialRevision create(@Nonnull SCMHead branch) {
+                                    return new MercurialRevision(branch, nodeBranch[0]);
+                                }
+                            }, new SCMSourceRequest.ProbeLambda<SCMHead, MercurialRevision>() {
+                                @Override
+                                public @Nonnull
+                                SCMSourceCriteria.Probe create(@Nonnull SCMHead branch, @Nullable final
+                                MercurialRevision revision) {
+                                    return new SCMProbe() {
+                                        @Override
+                                        public @Nonnull
+                                        SCMProbeStat stat(@Nonnull String path) throws IOException {
+                                            try {
+                                                String files = hg.popen(cache, listener, true,
+                                                        new ArgumentListBuilder("locate",
+                                                                "-r",
+                                                                revision.getHash(),
+                                                                "-I",
+                                                                "path:" + path));
+                                                if (StringUtils.isBlank(files)) {
+                                                    return SCMProbeStat.fromType(SCMFile.Type.NONEXISTENT);
+                                                }
+                                                return SCMProbeStat.fromType(SCMFile.Type.REGULAR_FILE);
+                                            } catch (InterruptedException e) {
+                                                throw new IOException(e);
+                                            }
+                                        }
+
+                                        @Override
+                                        public void close() throws IOException {
+                                        }
+
+                                        @Override
+                                        public String name() {
+                                            return name;
+                                        }
+
+                                        @Override
+                                        public long lastModified() {
+                                            return 0;
+                                        }
+                                    };
+                                }
+                            }, new SCMSourceRequest.Witness() {
+                                @Override
+                                public void record(@NonNull SCMHead branch, SCMRevision revision, boolean isMatch) {
+                                    if (revision == null) {
+                                        listener.getLogger().println("Ignored branch " + branch.getName());
+                                    } else {
+                                        listener.getLogger().println("Found branch " + branch.getName());
+                                        if (isMatch) {
+                                            listener.getLogger().println("  Met criteria");
+                                        } else {
+                                            listener.getLogger().println("  Does not meet criteria");
+                                        }
+                                    }
+                                }
+                            })) {
+                        listener.getLogger().format("Processed %d branches (query complete)%n", count);
+                        return;
+                    }
+                }
+                listener.getLogger().format("Processed %d branches%n", count);
+            } finally {
+                hg.close();
+            }
         }
     }
 
-    @SuppressWarnings("DB_DUPLICATE_BRANCHES")
-    @Override public SCM build(SCMHead head, SCMRevision revision) {
-        String rev = revision == null ? head.getName() : ((MercurialRevision) revision).hash;
-        return new MercurialSCM(installation, source, revision == null ? MercurialSCM.RevisionType.BRANCH : MercurialSCM.RevisionType.CHANGESET, rev, modules, subdir, browser, clean, credentialsId, false);
+    protected @Nonnull MercurialSCMBuilder<?> newBuilder(@Nonnull SCMHead head, @CheckForNull SCMRevision revision) {
+        return new MercurialSCMBuilder<>(head, revision, source, credentialsId);
     }
 
-    private @CheckForNull StandardUsernameCredentials getCredentials() {
+    protected void decorate(@Nonnull MercurialSCMBuilder<?> builder) {}
+
+    @Override public @Nonnull SCM build(@Nonnull SCMHead head, @CheckForNull SCMRevision revision) {
+        MercurialSCMBuilder<?> builder = newBuilder(head, revision).withTraits(traits);
+        decorate(builder);
+        return builder.build();
+    }
+
+    private @CheckForNull StandardUsernameCredentials getCredentials(@CheckForNull String credentialsId) {
         if (credentialsId != null) {
             for (StandardUsernameCredentials c : availableCredentials(getOwner(), source)) {
                 if (c.getId().equals(credentialsId)) {
@@ -207,9 +318,7 @@ public final class MercurialSCMSource extends SCMSource {
         return null;
     }
 
-    @NonNull
-    @Override
-    protected List<Action> retrieveActions(@NonNull SCMHead head,
+    @Override protected @Nonnull List<Action> retrieveActions(@NonNull SCMHead head,
                                            @edu.umd.cs.findbugs.annotations.CheckForNull SCMHeadEvent event,
                                            @NonNull TaskListener listener) throws IOException, InterruptedException {
         // TODO for Mercurial 2.4+ check for the bookmark called @ and resolve that to determine the primary
@@ -219,7 +328,8 @@ public final class MercurialSCMSource extends SCMSource {
         return Collections.emptyList();
     }
 
-    private static List<? extends StandardUsernameCredentials> availableCredentials(@CheckForNull SCMSourceOwner owner, @CheckForNull String source) {
+    private static @Nonnull List<? extends StandardUsernameCredentials> availableCredentials(
+            @CheckForNull SCMSourceOwner owner, @CheckForNull String source) {
         return CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, owner, null, URIRequirementBuilder.fromUri(source).build());
     }
 
@@ -238,7 +348,8 @@ public final class MercurialSCMSource extends SCMSource {
                     .withAll(availableCredentials(owner, source));
         }
 
-        public FormValidation doCheckBranchPattern(@QueryParameter String value) {
+        @Deprecated @Restricted(DoNotUse.class) @RestrictedSince("2.0") public FormValidation doCheckBranchPattern(
+                @QueryParameter String value) {
             try {
                 Pattern.compile(value);
                 return FormValidation.ok();
@@ -247,15 +358,26 @@ public final class MercurialSCMSource extends SCMSource {
             }
         }
 
+        @Deprecated
+        @Restricted(DoNotUse.class)
+        @RestrictedSince("2.0")
         public List<Descriptor<RepositoryBrowser<?>>> getBrowserDescriptors() {
             return RepositoryBrowsers.filter(HgBrowser.class);
+        }
+
+        public List<SCMSourceTraitDescriptor> getTraitDescriptors() {
+            return SCMSourceTrait._for(this, MercurialSCMSourceContext.class, MercurialSCMBuilder.class);
+        }
+
+        public List<SCMSourceTrait> getTraitDefaults() {
+            return Collections.emptyList();
         }
 
     }
 
     /*package*/ static final class MercurialRevision extends SCMRevision {
-        private final String hash;
-        MercurialRevision(SCMHead branch, String hash) {
+        @Nonnull private final String hash;
+        MercurialRevision(@Nonnull SCMHead branch, @Nonnull String hash) {
             super(branch);
             this.hash = hash;
         }
@@ -267,6 +389,9 @@ public final class MercurialSCMSource extends SCMSource {
         }
         @Override public String toString() {
             return getHead().getName() + ":" + hash;
+        }
+        public @Nonnull String getHash() {
+            return hash;
         }
     }
 

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSourceContext.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSourceContext.java
@@ -1,0 +1,49 @@
+package hudson.plugins.mercurial;
+
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import hudson.model.TaskListener;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
+import jenkins.scm.api.trait.SCMSourceContext;
+
+public class MercurialSCMSourceContext<C extends MercurialSCMSourceContext<C>> extends SCMSourceContext<C, MercurialSCMSourceRequest> {
+    /**
+     * The {@link IdCredentials#getId()} of the credentials to use or {@code null} to use none / the installation defaults.
+     */
+    private String credentialsId;
+    /**
+     * The {@link MercurialInstallation#getName()}.
+     */
+    private String installation;
+
+    public MercurialSCMSourceContext(@CheckForNull SCMSourceCriteria criteria,
+                                     @Nonnull SCMHeadObserver observer) {
+        super(criteria, observer);
+    }
+
+    public final String credentialsId() {
+        return credentialsId;
+    }
+
+    public final String installation() {
+        return installation;
+    }
+
+    @SuppressWarnings("unchecked") public @Nonnull C withCredentialsId(String credentialsId) {
+        this.credentialsId = credentialsId;
+        return (C) this;
+    }
+
+    @SuppressWarnings("unchecked") public @Nonnull C withInstallation(String installation) {
+        this.installation = installation;
+        return (C) this;
+    }
+
+    @Override public @Nonnull MercurialSCMSourceRequest newRequest(@Nonnull SCMSource scmSource,
+                                                                   @CheckForNull TaskListener taskListener) {
+        return new MercurialSCMSourceRequest((MercurialSCMSource) scmSource, this, taskListener);
+    }
+}

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSourceContext.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSourceContext.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 package hudson.plugins.mercurial;
 
 import com.cloudbees.plugins.credentials.common.IdCredentials;

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSourceRequest.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSourceRequest.java
@@ -1,0 +1,32 @@
+package hudson.plugins.mercurial;
+
+import hudson.model.TaskListener;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.scm.api.trait.SCMSourceRequest;
+
+public class MercurialSCMSourceRequest extends SCMSourceRequest {
+    private final String credentialsId;
+    private final String installation;
+    private final String source;
+    protected MercurialSCMSourceRequest(@Nonnull MercurialSCMSource source,
+                                        @Nonnull MercurialSCMSourceContext<?> context,
+                                        @CheckForNull TaskListener listener) {
+        super(source, context, listener);
+        this.credentialsId = context.credentialsId();
+        this.installation = context.installation();
+        this.source = source.getSource();
+    }
+
+    public String installation() {
+        return this.installation;
+    }
+
+    public String credentialsId() {
+        return this.credentialsId;
+    }
+
+    public String source() {
+        return this.source;
+    }
+}

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSourceRequest.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSourceRequest.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 package hudson.plugins.mercurial;
 
 import hudson.model.TaskListener;

--- a/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
@@ -9,8 +9,23 @@ import hudson.model.UnprotectedRootAction;
 import hudson.scm.SCM;
 import hudson.security.ACL;
 import hudson.triggers.SCMTrigger;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.servlet.ServletException;
+import jenkins.model.Jenkins;
 import jenkins.scm.api.SCMEvent;
 import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceOwner;
+import jenkins.scm.api.SCMSourceOwners;
+import jenkins.triggers.SCMTriggerItem;
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
@@ -21,23 +36,9 @@ import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static javax.servlet.http.HttpServletResponse.*;
-import jenkins.model.Jenkins;
-import jenkins.scm.api.SCMSource;
-import jenkins.scm.api.SCMSourceOwner;
-import jenkins.scm.api.SCMSourceOwners;
-import jenkins.triggers.SCMTriggerItem;
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
 /**
  * Information screen for the use of Mercurial in Jenkins.
  */
@@ -206,7 +207,7 @@ public class MercurialStatus extends AbstractModelObject implements UnprotectedR
                 scmFound = true;
                 MercurialSCMSource hgSource = (MercurialSCMSource) source;
                 String repository = hgSource.getSource();
-                if (repository == null) {
+                if (StringUtils.isBlank(repository)) {
                     LOGGER.log(Level.WARNING, "project {0} is using source control but does not identify a repository", project.getFullName());
                     continue;
                 }

--- a/src/main/java/hudson/plugins/mercurial/traits/CleanMercurialSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/CleanMercurialSCMSourceTrait.java
@@ -1,7 +1,9 @@
 package hudson.plugins.mercurial.traits;
 
 import hudson.Extension;
+import hudson.plugins.mercurial.MercurialSCM;
 import hudson.plugins.mercurial.MercurialSCMBuilder;
+import hudson.plugins.mercurial.MercurialSCMSource;
 import hudson.scm.SCM;
 import javax.annotation.Nonnull;
 import jenkins.scm.api.trait.SCMBuilder;
@@ -9,10 +11,21 @@ import jenkins.scm.api.trait.SCMSourceTrait;
 import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+/**
+ * A {@link SCMSourceTrait} for {@link MercurialSCMSource} that configures {@link MercurialSCM#setClean(boolean)}.
+ *
+ * @since 2.0
+ */
 public class CleanMercurialSCMSourceTrait extends SCMSourceTrait {
+    /**
+     * Constructor.
+     */
     @DataBoundConstructor public CleanMercurialSCMSourceTrait() { }
 
-    @Override protected <B extends SCMBuilder<B, S>, S extends SCM> void decorateBuilder(B builder) {
+    /**
+     * {@inheritDoc}
+     */
+    @Override protected void decorateBuilder(SCMBuilder<?, ?> builder) {
         ((MercurialSCMBuilder<?>) builder).withClean(true);
     }
 
@@ -21,9 +34,18 @@ public class CleanMercurialSCMSourceTrait extends SCMSourceTrait {
             return "Clean Build";
         }
 
-        @Override public boolean isApplicableToBuilder(@Nonnull Class<? extends SCMBuilder> builderClass) {
-            return MercurialSCMBuilder.class.isAssignableFrom(builderClass)
-                    && super.isApplicableToBuilder(builderClass);
+        /**
+         * {@inheritDoc}
+         */
+        @Override public Class<? extends SCMBuilder> getBuilderClass() {
+            return MercurialSCMBuilder.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public Class<? extends SCM> getScmClass() {
+            return MercurialSCM.class;
         }
     }
 }

--- a/src/main/java/hudson/plugins/mercurial/traits/CleanMercurialSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/CleanMercurialSCMSourceTrait.java
@@ -1,3 +1,28 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 package hudson.plugins.mercurial.traits;
 
 import hudson.Extension;
@@ -31,7 +56,7 @@ public class CleanMercurialSCMSourceTrait extends SCMSourceTrait {
 
     @Extension public static class DescriptorImpl extends SCMSourceTraitDescriptor {
         @Override public @Nonnull String getDisplayName() {
-            return "Clean Build";
+            return Messages.CleanMercurialSCMSourceTrait_displayName();
         }
 
         /**

--- a/src/main/java/hudson/plugins/mercurial/traits/CleanMercurialSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/CleanMercurialSCMSourceTrait.java
@@ -1,0 +1,29 @@
+package hudson.plugins.mercurial.traits;
+
+import hudson.Extension;
+import hudson.plugins.mercurial.MercurialSCMBuilder;
+import hudson.scm.SCM;
+import javax.annotation.Nonnull;
+import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class CleanMercurialSCMSourceTrait extends SCMSourceTrait {
+    @DataBoundConstructor public CleanMercurialSCMSourceTrait() { }
+
+    @Override protected <B extends SCMBuilder<B, S>, S extends SCM> void decorateBuilder(B builder) {
+        ((MercurialSCMBuilder<?>) builder).withClean(true);
+    }
+
+    @Extension public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+        @Override public @Nonnull String getDisplayName() {
+            return "Clean Build";
+        }
+
+        @Override public boolean isApplicableToBuilder(@Nonnull Class<? extends SCMBuilder> builderClass) {
+            return MercurialSCMBuilder.class.isAssignableFrom(builderClass)
+                    && super.isApplicableToBuilder(builderClass);
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/mercurial/traits/MercurialBrowserSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/MercurialBrowserSCMSourceTrait.java
@@ -29,6 +29,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Descriptor;
+import hudson.plugins.mercurial.MercurialSCM;
 import hudson.plugins.mercurial.MercurialSCMBuilder;
 import hudson.plugins.mercurial.MercurialSCMSource;
 import hudson.plugins.mercurial.browser.HgBrowser;
@@ -47,7 +48,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * Exposes {@link HgBrowser} configuration of a {@link MercurialSCMSource} as a {@link SCMSourceTrait}.
  *
- * @since 3.4.0
+ * @since 2.0
  */
 public class MercurialBrowserSCMSourceTrait extends SCMSourceTrait {
 
@@ -80,22 +81,19 @@ public class MercurialBrowserSCMSourceTrait extends SCMSourceTrait {
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected <B extends SCMBuilder<B, S>, S extends SCM> void decorateBuilder(B builder) {
+    @Override protected void decorateBuilder(SCMBuilder<?, ?> builder) {
         ((MercurialSCMBuilder<?>) builder).withBrowser(browser);
     }
 
     /**
      * Our {@link Descriptor}
      */
-    @Extension
-    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+    @Extension public static class DescriptorImpl extends SCMSourceTraitDescriptor {
 
         /**
          * {@inheritDoc}
          */
-        @Override
-        public @Nonnull String getDisplayName() {
+        @Override public @Nonnull String getDisplayName() {
             return "Configure Repository Browser";
         }
 
@@ -112,10 +110,15 @@ public class MercurialBrowserSCMSourceTrait extends SCMSourceTrait {
         /**
          * {@inheritDoc}
          */
-        @Override
-        public boolean isApplicableToBuilder(@NonNull Class<? extends SCMBuilder> builderClass) {
-            return super.isApplicableToBuilder(builderClass)
-                    && MercurialSCMBuilder.class.isAssignableFrom(builderClass);
+        @Override public Class<? extends SCMBuilder> getBuilderClass() {
+            return MercurialSCMBuilder.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public Class<? extends SCM> getScmClass() {
+            return MercurialSCM.class;
         }
     }
 }

--- a/src/main/java/hudson/plugins/mercurial/traits/MercurialBrowserSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/MercurialBrowserSCMSourceTrait.java
@@ -94,7 +94,7 @@ public class MercurialBrowserSCMSourceTrait extends SCMSourceTrait {
          * {@inheritDoc}
          */
         @Override public @Nonnull String getDisplayName() {
-            return "Configure Repository Browser";
+            return Messages.MercurialBrowserSCMSourceTrait_displayName();
         }
 
         /**

--- a/src/main/java/hudson/plugins/mercurial/traits/MercurialBrowserSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/MercurialBrowserSCMSourceTrait.java
@@ -1,0 +1,121 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package hudson.plugins.mercurial.traits;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.plugins.mercurial.MercurialSCMBuilder;
+import hudson.plugins.mercurial.MercurialSCMSource;
+import hudson.plugins.mercurial.browser.HgBrowser;
+import hudson.scm.RepositoryBrowser;
+import hudson.scm.RepositoryBrowsers;
+import hudson.scm.SCM;
+import java.util.List;
+import javax.annotation.Nonnull;
+import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Exposes {@link HgBrowser} configuration of a {@link MercurialSCMSource} as a {@link SCMSourceTrait}.
+ *
+ * @since 3.4.0
+ */
+public class MercurialBrowserSCMSourceTrait extends SCMSourceTrait {
+
+    /**
+     * The configured {@link HgBrowser} or {@code null} to use the "auto" browser.
+     */
+    @CheckForNull
+    private final HgBrowser browser;
+
+    /**
+     * Stapler constructor.
+     *
+     * @param browser the {@link HgBrowser} or {@code null} to use the "auto" browser.
+     */
+    @DataBoundConstructor
+    public MercurialBrowserSCMSourceTrait(@CheckForNull HgBrowser browser) {
+        this.browser = browser;
+    }
+
+    /**
+     * Gets the {@link HgBrowser}..
+     *
+     * @return the {@link HgBrowser} or {@code null} to use the "auto" browser.
+     */
+    @CheckForNull
+    public HgBrowser getBrowser() {
+        return browser;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected <B extends SCMBuilder<B, S>, S extends SCM> void decorateBuilder(B builder) {
+        ((MercurialSCMBuilder<?>) builder).withBrowser(browser);
+    }
+
+    /**
+     * Our {@link Descriptor}
+     */
+    @Extension
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public @Nonnull String getDisplayName() {
+            return "Configure Repository Browser";
+        }
+
+        /**
+         * Expose the {@link HgBrowser} instances to stapler.
+         *
+         * @return the {@link HgBrowser} instances
+         */
+        @Restricted(NoExternalUse.class) // stapler
+        public List<Descriptor<RepositoryBrowser<?>>> getBrowserDescriptors() {
+            return RepositoryBrowsers.filter(HgBrowser.class);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean isApplicableToBuilder(@NonNull Class<? extends SCMBuilder> builderClass) {
+            return super.isApplicableToBuilder(builderClass)
+                    && MercurialSCMBuilder.class.isAssignableFrom(builderClass);
+        }
+    }
+}

--- a/src/main/java/hudson/plugins/mercurial/traits/MercurialInstallationSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/MercurialInstallationSCMSourceTrait.java
@@ -49,7 +49,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /**
  * Exposes {@link MercurialInstallation} configuration of a {@link MercurialSCMSource} as a {@link SCMSourceTrait}.
  *
- * @since 3.4.0
+ * @since 2.0
  */
 public class MercurialInstallationSCMSourceTrait extends SCMSourceTrait {
     /**
@@ -78,14 +78,14 @@ public class MercurialInstallationSCMSourceTrait extends SCMSourceTrait {
     /**
      * {@inheritDoc}
      */
-    @Override protected <B extends SCMSourceContext<B, R>, R extends SCMSourceRequest> void decorateContext(B context) {
+    @Override protected void decorateContext(SCMSourceContext<?, ?> context) {
         ((MercurialSCMSourceContext<?>)context).withInstallation(installation);
     }
 
     /**
      * {@inheritDoc}
      */
-    @Override protected <B extends SCMBuilder<B, S>, S extends SCM> void decorateBuilder(B builder) {
+    @Override protected void decorateBuilder(SCMBuilder<?, ?> builder) {
         ((MercurialSCMBuilder<?>) builder).withInstallation(installation);
     }
 
@@ -104,8 +104,29 @@ public class MercurialInstallationSCMSourceTrait extends SCMSourceTrait {
         /**
          * {@inheritDoc}
          */
+        @Override public Class<? extends SCMBuilder> getBuilderClass() {
+            return MercurialSCMBuilder.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public Class<? extends SCMSourceContext> getContextClass() {
+            return MercurialSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public Class<? extends SCM> getScmClass() {
+            return MercurialSCM.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
         @Override public boolean isApplicableToBuilder(@Nonnull Class<? extends SCMBuilder> builderClass) {
-            if (super.isApplicableToBuilder(builderClass) && MercurialSCMBuilder.class.isAssignableFrom(builderClass)) {
+            if (super.isApplicableToBuilder(builderClass)) {
                 for (MercurialInstallation i : MercurialInstallation.allInstallations()) {
                     if (i.isUseCaches()) {
                         return true;
@@ -119,22 +140,28 @@ public class MercurialInstallationSCMSourceTrait extends SCMSourceTrait {
          * {@inheritDoc}
          */
         @Override public boolean isApplicableToContext(@Nonnull Class<? extends SCMSourceContext> contextClass) {
-            return super.isApplicableToContext(contextClass) && MercurialSCMSourceContext.class
-                    .isAssignableFrom(contextClass);
+            if (super.isApplicableToContext(contextClass)) {
+                for (MercurialInstallation i : MercurialInstallation.allInstallations()) {
+                    if (i.isUseCaches()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         /**
          * {@inheritDoc}
          */
         @Override public boolean isApplicableToSCM(@Nonnull Class<? extends SCM> scmClass) {
-            return super.isApplicableToSCM(scmClass) && MercurialSCM.class.isAssignableFrom(scmClass);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override public boolean isApplicableTo(@Nonnull SCMSource source) {
-            return super.isApplicableTo(source) && source instanceof MercurialSCMSource;
+            if (super.isApplicableToSCM(scmClass)) {
+                for (MercurialInstallation i : MercurialInstallation.allInstallations()) {
+                    if (i.isUseCaches()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
 
         /**

--- a/src/main/java/hudson/plugins/mercurial/traits/MercurialInstallationSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/MercurialInstallationSCMSourceTrait.java
@@ -98,7 +98,7 @@ public class MercurialInstallationSCMSourceTrait extends SCMSourceTrait {
          * {@inheritDoc}
          */
         @Override public @Nonnull String getDisplayName() {
-            return "Select Mercurial installation";
+            return Messages.MercurialInstallationSCMSourceTrait_displayName();
         }
 
         /**

--- a/src/main/java/hudson/plugins/mercurial/traits/MercurialInstallationSCMSourceTrait.java
+++ b/src/main/java/hudson/plugins/mercurial/traits/MercurialInstallationSCMSourceTrait.java
@@ -1,0 +1,157 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+package hudson.plugins.mercurial.traits;
+
+import hudson.Extension;
+import hudson.Util;
+import hudson.plugins.mercurial.MercurialInstallation;
+import hudson.plugins.mercurial.MercurialSCM;
+import hudson.plugins.mercurial.MercurialSCMBuilder;
+import hudson.plugins.mercurial.MercurialSCMSource;
+import hudson.plugins.mercurial.MercurialSCMSourceContext;
+import hudson.scm.SCM;
+import hudson.util.ListBoxModel;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMBuilder;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Exposes {@link MercurialInstallation} configuration of a {@link MercurialSCMSource} as a {@link SCMSourceTrait}.
+ *
+ * @since 3.4.0
+ */
+public class MercurialInstallationSCMSourceTrait extends SCMSourceTrait {
+    /**
+     * The {@link MercurialInstallation#getName()} or {@code null} to use the "system" default.
+     */
+    private final @CheckForNull String installation;
+
+    /**
+     * Stapler constructor.
+     *
+     * @param installation the {@link MercurialInstallation#getName()} or {@code null} to use the "system" default.
+     */
+    @DataBoundConstructor public MercurialInstallationSCMSourceTrait(@CheckForNull String installation) {
+        this.installation = Util.fixEmpty(installation);
+    }
+
+    /**
+     * Returns the {@link MercurialInstallation#getName()}.
+     *
+     * @return the {@link MercurialInstallation#getName()} or {@code null} to use the "system" default.
+     */
+    public @CheckForNull String getInstallation() {
+        return installation;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override protected <B extends SCMSourceContext<B, R>, R extends SCMSourceRequest> void decorateContext(B context) {
+        ((MercurialSCMSourceContext<?>)context).withInstallation(installation);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override protected <B extends SCMBuilder<B, S>, S extends SCM> void decorateBuilder(B builder) {
+        ((MercurialSCMBuilder<?>) builder).withInstallation(installation);
+    }
+
+    /**
+     * Our {@link hudson.model.Descriptor}
+     */
+    @Extension public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public @Nonnull String getDisplayName() {
+            return "Select Mercurial installation";
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public boolean isApplicableToBuilder(@Nonnull Class<? extends SCMBuilder> builderClass) {
+            if (super.isApplicableToBuilder(builderClass) && MercurialSCMBuilder.class.isAssignableFrom(builderClass)) {
+                for (MercurialInstallation i : MercurialInstallation.allInstallations()) {
+                    if (i.isUseCaches()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public boolean isApplicableToContext(@Nonnull Class<? extends SCMSourceContext> contextClass) {
+            return super.isApplicableToContext(contextClass) && MercurialSCMSourceContext.class
+                    .isAssignableFrom(contextClass);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public boolean isApplicableToSCM(@Nonnull Class<? extends SCM> scmClass) {
+            return super.isApplicableToSCM(scmClass) && MercurialSCM.class.isAssignableFrom(scmClass);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override public boolean isApplicableTo(@Nonnull SCMSource source) {
+            return super.isApplicableTo(source) && source instanceof MercurialSCMSource;
+        }
+
+        /**
+         * Returns the list of {@link MercurialInstallation} items.
+         *
+         * @return the list of {@link MercurialInstallation} items.
+         */
+        @Restricted(NoExternalUse.class) // stapler
+        public ListBoxModel doFillInstallationItems() {
+            ListBoxModel result = new ListBoxModel();
+            for (MercurialInstallation i: MercurialInstallation.allInstallations()) {
+                if (i.isUseCaches()) {
+                    result.add(i.getName());
+                }
+            }
+            return result;
+        }
+
+    }
+}

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/config-detail.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/config-detail.jelly
@@ -1,37 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:t="/lib/hudson" xmlns:c="/lib/credentials">
-    <j:invokeStatic var="installations" className="hudson.plugins.mercurial.MercurialInstallation" method="allInstallations"/>
-    <f:entry title="Mercurial Version (caching required)">
-        <select class="setting-input" name="installation">
-            <j:forEach var="inst" items="${installations}">
-                <j:if test="${inst.useCaches}">
-                    <f:option selected="${inst.name==instance.installation}" value="${inst.name}">${inst.name}</f:option>
-                </j:if>
-            </j:forEach>
-        </select>
-    </f:entry>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:t="/lib/hudson" xmlns:c="/lib/credentials"
+         xmlns:scm="/jenkins/scm/api/form">
     <f:entry title="${%Project Repository}" field="source">
         <f:textbox/>
     </f:entry>
     <f:entry title="${%Credentials}" field="credentialsId">
         <c:select/>
     </f:entry>
-    <f:advanced>
-        <f:entry title="${%Branch inclusion pattern}" field="branchPattern">
-            <f:textbox/>
-        </f:entry>
-        <f:entry field="modules" title="${%Modules}">
-            <f:textbox/>
-        </f:entry>
-        <f:entry field="clean" title="${%Clean Build}">
-            <f:checkbox/>
-        </f:entry>
-        <f:entry field="subdir" title="${%Subdirectory}">
-            <f:textbox/>
-        </f:entry>
-    </f:advanced>
-    <j:set var="scm" value="${instance}"/>
-    <j:set var="scmd" value="${descriptor}"/>
-    <t:listScmBrowsers name="mercurial.browser"/>
+    <f:entry title="${%Behaviours}">
+        <scm:traits field="traits"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/config-detail_en.properties
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/config-detail_en.properties
@@ -1,0 +1,1 @@
+Behaviours=Behaviours

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/config-detail_en_US.properties
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/config-detail_en_US.properties
@@ -1,0 +1,1 @@
+Behaviours=Behaviors

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/help-branchPattern.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/help-branchPattern.html
@@ -1,4 +1,0 @@
-<div>
-    If not blank, a regular expression which a branch name must match.
-    (Implicitly anchored, i.e. the whole branch name must match.)
-</div>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/help-clean.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/help-clean.html
@@ -1,6 +1,0 @@
-<div>
-    When this option is checked, each build will wipe any local modifications
-    or untracked files in the repository checkout.
-    This is often a convenient way to ensure that a build is not
-    using any artifacts from earlier builds.
-</div>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/help-modules.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/help-modules.html
@@ -1,6 +1,0 @@
-<div>
-  Reduce unnecessary builds by specifying a comma or space delimited list of "modules" within the repository.
-  A module is a directory name within the repository that this project lives in. If this field is set,
-  changes outside the specified modules will not trigger a build (even though the whole repository is checked
-  out anyway due to the Mercurial limitation.)
-</div>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/help-subdir.html
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCMSource/help-subdir.html
@@ -1,5 +1,0 @@
-<div>
-  If not empty, check out the Mercurial repository into this subdirectory of the
-  job's workspace. For example: <code>my/sources</code> (use forward slashes).
-  If changing this entry, you probably want to clean the workspace first.
-</div>

--- a/src/main/resources/hudson/plugins/mercurial/traits/CleanMercurialSCMSourceTrait/help.html
+++ b/src/main/resources/hudson/plugins/mercurial/traits/CleanMercurialSCMSourceTrait/help.html
@@ -1,0 +1,6 @@
+<div>
+    When this behaviour is present, each build will wipe any local modifications
+    or untracked files in the repository checkout.
+    This is often a convenient way to ensure that a build is not
+    using any artifacts from earlier builds.
+</div>

--- a/src/main/resources/hudson/plugins/mercurial/traits/MercurialBrowserSCMSourceTrait/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/traits/MercurialBrowserSCMSourceTrait/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2017 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <j:set var="scm" value="${instance}"/>
+  <j:set var="scmd" value="${descriptor}"/>
+  <t:listScmBrowsers name="mercurial.browser"/>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/mercurial/traits/MercurialInstallationSCMSourceTrait/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/traits/MercurialInstallationSCMSourceTrait/config.jelly
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2017 CloudBees, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="Mercurial Version (caching required)" field="installation">
+    <f:select/>
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/mercurial/traits/Messages.properties
+++ b/src/main/resources/hudson/plugins/mercurial/traits/Messages.properties
@@ -1,0 +1,1 @@
+MercurialBrowserSCMSourceTrait.displayName=Configure Repository Browser

--- a/src/main/resources/hudson/plugins/mercurial/traits/Messages.properties
+++ b/src/main/resources/hudson/plugins/mercurial/traits/Messages.properties
@@ -1,1 +1,3 @@
+CleanMercurialSCMSourceTrait.displayName=Clean Build
 MercurialBrowserSCMSourceTrait.displayName=Configure Repository Browser
+MercurialInstallationSCMSourceTrait.displayName=Select Mercurial Installation


### PR DESCRIPTION
Downstream of https://github.com/jenkinsci/scm-api-plugin/pull/36

See [JENKINS-43507](https://issues.jenkins-ci.org/browse/JENKINS-43507)

@reviewbybees

Todo
- [x] Ensure that the trait implementations work correctly when BitBucket branch source picks up traits