### PR TITLE
[JENKINS-45806] Mercurial doesn't use credentials in multibranch pipeline

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -190,6 +190,7 @@ public final class MercurialSCMSource extends SCMSource {
                             @CheckForNull SCMHeadEvent<?> event, @Nonnull final TaskListener listener)
             throws IOException, InterruptedException {
         try (MercurialSCMSourceRequest request= new MercurialSCMSourceContext<>(criteria, observer)
+                .withCredentialsId(credentialsId)
                 .withTraits(traits)
                 .newRequest(this, listener) ) {
             MercurialInstallation inst = MercurialSCM.findInstallation(request.installation());


### PR DESCRIPTION
This fixes the missing credentialsId when polling for changes in a multibranch pipeline (see https://issues.jenkins-ci.org/browse/JENKINS-45806 for details).