### PR TITLE
Update example hg web link

### DIFF
--- a/src/main/resources/hudson/plugins/mercurial/browser/HgWeb/help-url.html
+++ b/src/main/resources/hudson/plugins/mercurial/browser/HgWeb/help-url.html
@@ -1,3 +1,3 @@
 <div>
-  Specify the root URL serving this repository (such as <a href="http://selenic.com/repo/hg">this</a>.)
+  Specify the root URL serving this repository (such as <a href="https://www.mercurial-scm.org/repo/hg/">this</a>.)
 </div>


### PR DESCRIPTION
The main Mercurial repository was migrated from http://selenic.com/repo/hg to https://www.mercurial-scm.org/repo/hg/