### PR TITLE
#JENKINS-46851 Picking up the credentials ID for SCM revision retrieving

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMSource.java
@@ -265,6 +265,7 @@ public final class MercurialSCMSource extends SCMSource {
     protected SCMRevision retrieve(@NonNull String thingName, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
         try (MercurialSCMSourceRequest request = new MercurialSCMSourceContext<>(null, SCMHeadObserver.none())
+                .withCredentialsId(credentialsId)
                 .withTraits(traits)
                 .newRequest(this, listener)) {
             MercurialInstallation inst = MercurialSCM.findInstallation(request.installation());


### PR DESCRIPTION
[JENKINS-46851](https://issues.jenkins-ci.org/browse/JENKINS-46851)

Until the credential ID is missing it's not possible to set up Pipeline Shared Library with secured repository.