### PR TITLE
FIX repository cache w/o sharing fails on Windows

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -44,6 +44,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.net.MalformedURLException;


### PR DESCRIPTION
getRepoLocation() returns a path with a `/` separator, but on Windows hgrc contains `\` paths for local clones.
So I propose we simply search for the `default` path in the file and replace it without checking its value. After a clone it has been set by Mercurial and must match what we gave it, short of the directory separator.

I hesitated just replacing `\` by `/` in hgrcText, seeing how more complex the code looks now.