### PR TITLE
#JENKINS-55319 Mercurial plugin cannot handle spaces in file names

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
@@ -280,7 +280,7 @@ public class MercurialChangeSet extends ChangeLogSet.Entry {
     private List<String> toList(String list) {
         list = list.trim();
         if(list.length()==0) return Collections.emptyList();
-        return Arrays.asList(list.split("<file/>"));
+        return Arrays.asList(list.split(list.contains("<file/>") ? "<file/>" : " "));
     }
 
     /** |xmlescape handles a few cases that |escape does not */

--- a/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
@@ -280,13 +280,16 @@ public class MercurialChangeSet extends ChangeLogSet.Entry {
     private List<String> toList(String list) {
         list = list.trim();
         if(list.length()==0) return Collections.emptyList();
-        return Arrays.asList(list.split(" "));
+        return Arrays.asList(list.split("<file/>"));
     }
 
     /** |xmlescape handles a few cases that |escape does not */
     static final String CHANGELOG_TEMPLATE =
-            "<changeset node='{node}' author='{author|xmlescape}' rev='{rev}' date='{date}'>" +
+            "changeset = \"<changeset node='{node}' author='{author|xmlescape}' rev='{rev}' date='{date}'>" +
             // TODO {file_adds} and {file_dels} seem to be far slower to process than {files}
             "<msg>{desc|xmlescape}</msg><added>{file_adds|stringify|xmlescape}</added><deleted>{file_dels|stringify|xmlescape}</deleted>" +
-            "<files>{files|stringify|xmlescape}</files><parents>{parents}</parents></changeset>\\n";
+            "<files>{files|stringify|xmlescape}</files><parents>{parents}</parents></changeset>\\n\"" +
+            "\nfile = \"{file}<file/>\"" +
+            "\nfile_del = \"{file_del}<file/>\"" +
+            "\nfile_add = \"{file_add}<file/>\"";
 }

--- a/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialChangeSet.java
@@ -285,11 +285,9 @@ public class MercurialChangeSet extends ChangeLogSet.Entry {
 
     /** |xmlescape handles a few cases that |escape does not */
     static final String CHANGELOG_TEMPLATE =
-            "changeset = \"<changeset node='{node}' author='{author|xmlescape}' rev='{rev}' date='{date}'>" +
-            // TODO {file_adds} and {file_dels} seem to be far slower to process than {files}
-            "<msg>{desc|xmlescape}</msg><added>{file_adds|stringify|xmlescape}</added><deleted>{file_dels|stringify|xmlescape}</deleted>" +
-            "<files>{files|stringify|xmlescape}</files><parents>{parents}</parents></changeset>\\n\"" +
-            "\nfile = \"{file}<file/>\"" +
-            "\nfile_del = \"{file_del}<file/>\"" +
-            "\nfile_add = \"{file_add}<file/>\"";
+    		"<changeset node='{node}' author='{author|xmlescape}' rev='{rev}' date='{date}'>" +
+    		// TODO {file_adds} and {file_dels} seem to be far slower to process than {files}        
+    		"<msg>{desc|xmlescape}</msg><added>{file_adds % '{file_add}<file/>' |stringify|xmlescape}</added>" +
+    		"<deleted>{file_dels % '{file_del}<file/>' |stringify|xmlescape}</deleted>" +
+    		"<files>{files % '{file}<file/>' |stringify|xmlescape}</files><parents>{parents}</parents></changeset>\n";
 }

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -662,6 +662,15 @@ public class MercurialSCM extends SCM implements Serializable {
             return;
         }
         
+        try {
+        // Set up a changelog style file to allow for better logging
+        File style = File.createTempFile("style", ".tmp");
+        style.setWritable(true);
+        style.deleteOnExit();
+        FileOutputStream styleStream = new FileOutputStream(style);
+        styleStream.write(MercurialChangeSet.CHANGELOG_TEMPLATE.getBytes("UTF-8"));
+        styleStream.close();
+        
         // calc changelog
         final FileOutputStream os = new FileOutputStream(changelogFile);
         try {
@@ -670,7 +679,7 @@ public class MercurialSCM extends SCM implements Serializable {
                 os.write("<changesets>\n".getBytes("UTF-8"));
                 ArgumentListBuilder args = hg.seed(false);
                 args.add("log");
-                args.add("--template", MercurialChangeSet.CHANGELOG_TEMPLATE);
+                args.add("--style", style.getAbsolutePath());
                 if(revisionType == RevisionType.REVSET) {
                     args.add("--rev", "ancestors(" + revToBuild + ") and not ancestors(" + prevTag.getId() + ")");
                 }
@@ -693,6 +702,7 @@ public class MercurialSCM extends SCM implements Serializable {
         } finally {
             os.close();
         }
+        } finally {}
         } finally {
             hg.close();
         }

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -662,7 +662,6 @@ public class MercurialSCM extends SCM implements Serializable {
             return;
         }
         
-        
         // calc changelog
         final FileOutputStream os = new FileOutputStream(changelogFile);
         try {

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -662,14 +662,6 @@ public class MercurialSCM extends SCM implements Serializable {
             return;
         }
         
-        try {
-        // Set up a changelog style file to allow for better logging
-        File style = File.createTempFile("style", ".tmp");
-        style.setWritable(true);
-        style.deleteOnExit();
-        FileOutputStream styleStream = new FileOutputStream(style);
-        styleStream.write(MercurialChangeSet.CHANGELOG_TEMPLATE.getBytes("UTF-8"));
-        styleStream.close();
         
         // calc changelog
         final FileOutputStream os = new FileOutputStream(changelogFile);
@@ -679,7 +671,7 @@ public class MercurialSCM extends SCM implements Serializable {
                 os.write("<changesets>\n".getBytes("UTF-8"));
                 ArgumentListBuilder args = hg.seed(false);
                 args.add("log");
-                args.add("--style", style.getAbsolutePath());
+                args.add("--template", MercurialChangeSet.CHANGELOG_TEMPLATE);
                 if(revisionType == RevisionType.REVSET) {
                     args.add("--rev", "ancestors(" + revToBuild + ") and not ancestors(" + prevTag.getId() + ")");
                 }
@@ -702,7 +694,6 @@ public class MercurialSCM extends SCM implements Serializable {
         } finally {
             os.close();
         }
-        } finally {}
         } finally {
             hg.close();
         }

--- a/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
+++ b/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
@@ -234,32 +234,32 @@ public abstract class SCMTestBase {
                 entry.getAffectedPaths()));
         assertFalse(it.hasNext());
         p.setScm(new MercurialSCM(hgInstallation(), repo.getPath(), null,
-                "dir1 extra", null, null, false));
+                "dir\\ 1 extra", null, null, false));
         // dir2/f2 change should be ignored.
-        m.touchAndCommit(repo, "dir1/f2");
+        m.touchAndCommit(repo, "dir 1/f2");
         m.touchAndCommit(repo, "dir2/f2");
         it = p.scheduleBuild2(0).get().getChangeSet().iterator();
         assertTrue(it.hasNext());
         entry = it.next();
-        assertEquals(Collections.singleton("dir1/f2"), new HashSet<String>(
+        assertEquals(Collections.singleton("dir 1/f2"), new HashSet<String>(
                 entry.getAffectedPaths()));
         assertFalse(it.hasNext());
         // First commit should match (because at least one file does) but not
         // second.
-        m.touchAndCommit(repo, "dir2/f3", "dir1/f3");
+        m.touchAndCommit(repo, "dir2/f3", "dir 1/f3");
         m.touchAndCommit(repo, "dir2/f4", "dir2/f5");
         it = p.scheduleBuild2(0).get().getChangeSet().iterator();
         assertTrue(it.hasNext());
         entry = it.next();
-        assertEquals(new HashSet<String>(Arrays.asList("dir1/f3", "dir2/f3")),
+        assertEquals(new HashSet<String>(Arrays.asList("dir 1/f3", "dir2/f3")),
                 new HashSet<String>(entry.getAffectedPaths()));
         assertFalse(it.hasNext());
         // Any module in the list can trigger an inclusion.
-        m.touchAndCommit(repo, "extra/f1");
+        m.touchAndCommit(repo, "extra/subdir 1/file 1.txt");
         it = p.scheduleBuild2(0).get().getChangeSet().iterator();
         assertTrue(it.hasNext());
         entry = it.next();
-        assertEquals(Collections.singleton("extra/f1"), new HashSet<String>(
+        assertEquals(Collections.singleton("extra/subdir 1/file 1.txt"), new HashSet<String>(
                 entry.getAffectedPaths()));
         assertFalse(it.hasNext());
     }


### PR DESCRIPTION
I've modified the changelog template to split filenames with a <file/> tag, so as to prevent filenames with spaces in them from breaking the XML parsing.
In addition, the changelog template is now written to a temporary file, to allow for the changelog generation to work as expected.

Please note that this change will break changelog parsing for changelogs generated by existing versions.

Jenkins bug report link: [https://issues.jenkins-ci.org/browse/JENKINS-55319](https://issues.jenkins-ci.org/browse/JENKINS-55319)