### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
@@ -9,17 +9,17 @@
   <f:entry title="${%Executable}" field="executable">
     <f:textbox default="INSTALLATION/bin/hg"/>
   </f:entry>
-  <f:entry field="useCaches" title="${%Use Repository Caches}">
-    <f:checkbox/>
+  <f:entry field="useCaches">
+    <f:checkbox title="${%Use Repository Caches}" />
   </f:entry>
   <f:entry field="masterCacheRoot" title="${%Master cache directory}">
     <f:textbox/>
   </f:entry>
-  <f:entry field="useSharing" title="${%Use Repository Sharing}">
-    <f:checkbox/>
+  <f:entry field="useSharing>
+    <f:checkbox title="${%Use Repository Sharing}" />
   </f:entry>
-  <f:entry field="debug" title="${%Debug Flag}">
-    <f:checkbox/>
+  <f:entry field="debug">
+    <f:checkbox title="${%Debug Flag}" />
   </f:entry>
   <f:entry field="config" title="${%Custom Configuration}">
     <f:textarea/>

--- a/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialInstallation/config.jelly
@@ -15,7 +15,7 @@
   <f:entry field="masterCacheRoot" title="${%Master cache directory}">
     <f:textbox/>
   </f:entry>
-  <f:entry field="useSharing>
+  <f:entry field="useSharing">
     <f:checkbox title="${%Use Repository Sharing}" />
   </f:entry>
   <f:entry field="debug">

--- a/src/main/resources/hudson/plugins/mercurial/MercurialSCM/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/MercurialSCM/config.jelly
@@ -29,14 +29,14 @@
     <f:entry field="modules" title="${%Modules}">
       <f:textbox/>
     </f:entry>
-    <f:entry field="clean" title="${%Clean Build}">
-      <f:checkbox/>
+    <f:entry field="clean">
+      <f:checkbox title="${%Clean Build}" />
     </f:entry>
     <f:entry field="subdir" title="${%Subdirectory}">
       <f:textbox/>
     </f:entry>
-    <f:entry field="disableChangeLog" title="${%Disable Changelog}">
-      <f:checkbox/>
+    <f:entry field="disableChangeLog">
+      <f:checkbox title="${%Disable Changelog}" />
     </f:entry>
   </f:advanced>
 


### PR DESCRIPTION
[https://issues.jenkins-ci.org/browse/JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

This supersedes #122