### PR TITLE
Fix docker fixtures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
         <dependency>
             <groupId>org.jenkins-ci.test</groupId>
             <artifactId>docker-fixtures</artifactId>
-            <version>1.6</version>
+            <version>1.8</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/resources/hudson/plugins/mercurial/MercurialContainer/Dockerfile
+++ b/src/test/resources/hudson/plugins/mercurial/MercurialContainer/Dockerfile
@@ -1,9 +1,9 @@
-FROM jenkins/java:6894df180381
+FROM jenkins/java:d93654cc6239
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-        python2.7=2.7.14-2ubuntu2 \
-        python=2.7.14-2ubuntu1 \
-        libpython2.7-dev=2.7.14-2ubuntu2 \
+        python2.7 \
+        python \
+        libpython2.7-dev \
         make \
         gcc \
         gettext


### PR DESCRIPTION
The old version could not be used anymore. Building the ssh container failed due to issues with the used ubuntu base image.

For the respective change in docker-fixtures see: https://github.com/jenkinsci/docker-fixtures/pull/21