### PR TITLE
Upgrade to Java 8 and latest parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.2</version>
+        <version>3.46</version>
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
@@ -14,8 +15,8 @@
     <url>https://wiki.jenkins.io/display/JENKINS/Mercurial+Plugin</url>
     
     <properties>
-      <jenkins.version>2.7.3</jenkins.version>
-      <java.level>7</java.level>
+      <jenkins.version>2.60.1</jenkins.version>
+      <java.level>8</java.level>
       <no-test-jar>false</no-test-jar>
       <scm-api-plugin.version>2.2.0</scm-api-plugin.version>
     </properties>
@@ -80,7 +81,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.10</version>
+            <version>2.1.11</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Raise minimum Jenkins version to 1st LTS release with Java 8 support.

The "credentials" plugin required a small update, otherwise InjectedTest would fail with:
> Folders Plugin v6.1.0 failed to load.
> Credentials Plugin v2.1.10 is older than required. To fix, install v2.1.11 or later.