### PR TITLE
Switch to a BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.46</version>
+        <version>3.48</version>
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
@@ -15,10 +15,9 @@
     <url>https://wiki.jenkins.io/display/JENKINS/Mercurial+Plugin</url>
     
     <properties>
-      <jenkins.version>2.107.3</jenkins.version>
+      <jenkins.version>2.138.4</jenkins.version>
       <java.level>8</java.level>
       <no-test-jar>false</no-test-jar>
-      <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
     </properties>
     
     <developers>
@@ -72,26 +71,29 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.138.1</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.9</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.11</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>${scm-api-plugin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-credentials</artifactId>
-            <version>1.12</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -101,7 +103,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-project</artifactId>
-            <version>1.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -115,6 +116,7 @@
             <version>0.5.2</version>
         </dependency>
         <dependency>
+            <!-- TODO replace with MockAuthorizationStrategy -->
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
             <version>1.2</version>
@@ -123,7 +125,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>${scm-api-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -142,38 +143,27 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-step-api</artifactId>
-            <version>2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.1</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.22</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -185,7 +175,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>ssh-slaves</artifactId>
-            <version>1.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
+++ b/src/test/java/hudson/plugins/mercurial/HgExeFunctionalTest.java
@@ -90,7 +90,7 @@ public class HgExeFunctionalTest {
 
     @Test public void credentialsSSHKeyTest() throws Exception {
         BasicSSHUserPrivateKey.PrivateKeySource source = new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(
-                "test key");
+                "test key\n");
         BasicSSHUserPrivateKey credentials = new BasicSSHUserPrivateKey(
                 CredentialsScope.GLOBAL, "", "testuser", source, null, null);
 
@@ -99,7 +99,7 @@ public class HgExeFunctionalTest {
             Matcher matcher = Pattern.compile("ssh\\s-i\\s(.+)\\s-l\\stestuser").matcher(b.toCommandArray()[2]);
             matcher.find();
             String fileName = matcher.group(1);
-            assertEquals("test key", FileUtils.readFileToString(new File(fileName)));
+            assertEquals("test key\n", FileUtils.readFileToString(new File(fileName)));
             assertEquals(new ArgumentListBuilder("hg", "--config", "******").toString(), b.toString());
         }
     }


### PR DESCRIPTION
May as a side effect fix a PCT failure reported by @bmunozm, probably caused by mismatch between `workflow-support` versions in primary and `tests` classifier:

```
java.io.IOException: Pipeline: Groovy version 2.71 failed to load.
 - Pipeline: Supporting APIs version 2.17 is older than required. To fix, install version 3.3 or later.
```