### PR TITLE
Add SCM-Manager repository browser

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/browser/ScmManager.java
+++ b/src/main/java/hudson/plugins/mercurial/browser/ScmManager.java
@@ -62,12 +62,16 @@ public class ScmManager extends HgBrowser {
 
     @Override
     public FormValidation doCheckUrl(@QueryParameter String url) {
-      if (url.matches("https?://.*/repo/[^/]+/[^/]+/?")) {
+      return _doCheckUrl(url);
+    }
+
+    @Override
+    protected FormValidation check(URL url) {
+      if (url.toString().matches("https?://.*/repo/[^/]+/[^/]+/?")) {
         return FormValidation.ok();
       } else {
         return FormValidation.warning("Possibly incorrect root URL; expected URL which starts with http or https and ends with /repo/namespace/name");
       }
     }
-
   }
 }

--- a/src/main/java/hudson/plugins/mercurial/browser/ScmManager.java
+++ b/src/main/java/hudson/plugins/mercurial/browser/ScmManager.java
@@ -1,0 +1,73 @@
+package hudson.plugins.mercurial.browser;
+
+import hudson.Extension;
+import hudson.plugins.mercurial.MercurialChangeSet;
+import hudson.util.FormValidation;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Mercurial web interface served using a <a href="https://scm-manager.org/">SCM-Manager</a> repository.
+ */
+public class ScmManager extends HgBrowser {
+
+  @DataBoundConstructor
+  public ScmManager(String url) throws MalformedURLException {
+    super(url);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public URL getChangeSetLink(MercurialChangeSet changeSet) throws IOException {
+    current = changeSet;
+    return new URL(getUrl(), "code/changeset/" + changeSet.getNode());
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * Throws {@link IllegalStateException} when this method is called before at least one call
+   * to {@literal getChangeSetLink(MercurialChangeSet)}.
+   */
+  @Override
+  public URL getFileLink(String path) throws MalformedURLException {
+    checkCurrentIsNotNull();
+    return new URL(getUrl(), "code/sources/" + current.getNode() + "/" + path);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * Throws {@link IllegalStateException} when this method is called before at least one call
+   * to {@literal getChangeSetLink(MercurialChangeSet)}.
+   */
+  @Override
+  public URL getDiffLink(String path) throws MalformedURLException {
+    checkCurrentIsNotNull();
+    return new URL(getUrl(), "code/changeset/" + current.getNode() + "/#diff-" + path);
+  }
+
+  @Extension
+  public static class DescriptorImpl extends HgBrowser.HgBrowserDescriptor {
+
+    public String getDisplayName() {
+      return "SCM-Manager";
+    }
+
+    @Override
+    public FormValidation doCheckUrl(@QueryParameter String url) {
+      if (url.matches("https?://.*/repo/[^/]+/[^/]+/?")) {
+        return FormValidation.ok();
+      } else {
+        return FormValidation.warning("Possibly incorrect root URL; expected url which starts with http or https and ends with /repo/namespace/name");
+      }
+    }
+
+  }
+}

--- a/src/main/java/hudson/plugins/mercurial/browser/ScmManager.java
+++ b/src/main/java/hudson/plugins/mercurial/browser/ScmManager.java
@@ -45,7 +45,7 @@ public class ScmManager extends HgBrowser {
    * {@inheritDoc}
    *
    * Throws {@link IllegalStateException} when this method is called before at least one call
-   * to {@literal getChangeSetLink(MercurialChangeSet)}.
+   * to {@link #getChangeSetLink}.
    */
   @Override
   public URL getDiffLink(String path) throws MalformedURLException {
@@ -65,7 +65,7 @@ public class ScmManager extends HgBrowser {
       if (url.matches("https?://.*/repo/[^/]+/[^/]+/?")) {
         return FormValidation.ok();
       } else {
-        return FormValidation.warning("Possibly incorrect root URL; expected url which starts with http or https and ends with /repo/namespace/name");
+        return FormValidation.warning("Possibly incorrect root URL; expected URL which starts with http or https and ends with /repo/namespace/name");
       }
     }
 

--- a/src/main/java/hudson/plugins/mercurial/browser/ScmManager.java
+++ b/src/main/java/hudson/plugins/mercurial/browser/ScmManager.java
@@ -33,7 +33,7 @@ public class ScmManager extends HgBrowser {
    * {@inheritDoc}
    *
    * Throws {@link IllegalStateException} when this method is called before at least one call
-   * to {@literal getChangeSetLink(MercurialChangeSet)}.
+   * to {@link #getChangeSetLink}.
    */
   @Override
   public URL getFileLink(String path) throws MalformedURLException {

--- a/src/main/resources/hudson/plugins/mercurial/browser/ScmManager/config.jelly
+++ b/src/main/resources/hudson/plugins/mercurial/browser/ScmManager/config.jelly
@@ -1,0 +1,6 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry field="url" title="URL">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/mercurial/browser/ScmManager/help-url.html
+++ b/src/main/resources/hudson/plugins/mercurial/browser/ScmManager/help-url.html
@@ -1,3 +1,3 @@
 <div>
-    Specify the root URL serving this repository (such as <em>http://YOURSCMMANAGER/scm/repo/NAMESPACE/NAME/</em>).
+    Specify the root URL serving this repository (such as <code>http://YOURSCMMANAGER/scm/repo/NAMESPACE/NAME/</code>).
 </div>

--- a/src/main/resources/hudson/plugins/mercurial/browser/ScmManager/help-url.html
+++ b/src/main/resources/hudson/plugins/mercurial/browser/ScmManager/help-url.html
@@ -1,0 +1,3 @@
+<div>
+    Specify the root URL serving this repository (such as <em>http://YOURSCMMANAGER/scm/repo/NAMESPACE/NAME/</em>).
+</div>

--- a/src/test/java/hudson/plugins/mercurial/browser/ScmManagerTest.java
+++ b/src/test/java/hudson/plugins/mercurial/browser/ScmManagerTest.java
@@ -1,0 +1,30 @@
+package hudson.plugins.mercurial.browser;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+
+public class ScmManagerTest extends AbstractBrowserTestBase {
+
+  private static final String REPO_URL = "https://scm.hitchhiker.com/repo/spaceships/hog";
+
+  public ScmManagerTest() throws MalformedURLException {
+    super(new ScmManager(REPO_URL));
+  }
+
+  @Test
+  public void testGetChangeSetLinkMercurialChangeSet() throws IOException {
+    testGetChangeSetLinkMercurialChangeSet(REPO_URL+ "/code/changeset/6704efde87541766fadba17f66d04b926cd4d343");
+  }
+
+  @Test
+  public void testGetFileLink() throws IOException {
+    testGetFileLink(REPO_URL + "/code/sources/6704efde87541766fadba17f66d04b926cd4d343/src/main/java/hudson/plugins/mercurial/browser/HgBrowser.java");
+  }
+
+  @Test
+  public void testGetDiffLink() throws IOException {
+    testGetDiffLink(REPO_URL + "/code/changeset/6704efde87541766fadba17f66d04b926cd4d343/#diff-src/main/java/hudson/plugins/mercurial/browser/HgBrowser.java");
+  }
+}


### PR DESCRIPTION
This adds support for the [SCM-Manager](https://scm-manager.org) web frontend (like the already existing hgweb, bitbucket, etc). Generates URLs for viewing changesets, files and diffs.

It can be tested with the following public SCM-Manager repository [jenkins-plugin/hello-hg-shell](https://next-scm.cloudogu.com/scm/repo/jenkins-plugin/hello-hg-shell).