### PR TITLE
Fixing FunctionalTest.branches on newer Jenkins versions

### DIFF
--- a/src/test/java/hudson/plugins/mercurial/FunctionalTest.java
+++ b/src/test/java/hudson/plugins/mercurial/FunctionalTest.java
@@ -197,6 +197,9 @@ public class FunctionalTest {
         m.hg(repo, "branch", "b");
         m.touchAndCommit(repo, "b-1");
         FreeStyleProject p = j.createFreeStyleProject();
+        if (slave != null) {
+            p.setAssignedNode(slave);
+        }
         // Clone off b.
         p.setScm(new MercurialSCM(inst != null ? inst.getName() : null, repo.getRemote(), "b", null, null, null, false));
         m.buildAndCheck(p, "b-1");


### PR DESCRIPTION
This test started failing against 2.266 due apparently to https://github.com/jenkinsci/jenkins/pull/5028. (Not exactly sure how it _passed_ before that.)
