### PR TITLE
Removing integration with multiple-scms plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,6 @@
             <artifactId>matrix-project</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>multiple-scms</artifactId>
-            <version>0.6</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.ini4j</groupId>
             <artifactId>ini4j</artifactId>
             <version>0.5.4</version>

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -63,7 +63,6 @@ import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.ini4j.Ini;
-import org.jenkinsci.plugins.multiplescms.MultiSCMRevisionState;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -743,24 +742,7 @@ public class MercurialSCM extends SCM implements Serializable {
         String revToBuild = getRevision(env);
         if (build instanceof MatrixRun) {
             MatrixRun matrixRun = (MatrixRun) build;
-            MercurialTagAction parentRevision = null;
-
-            final Jenkins jenkins = Jenkins.getInstance();
-            if (jenkins != null && jenkins.getPlugin("multiple-scms") != null) {
-                MultiSCMRevisionState parentRevisions = matrixRun.getParentBuild().getAction(MultiSCMRevisionState.class);
-                if (parentRevisions != null) {
-                    SCMRevisionState _parentRevisions = parentRevisions.get(this, workspace, (MatrixRun) build);
-                    if (_parentRevisions instanceof MercurialTagAction) {
-                        parentRevision = (MercurialTagAction)_parentRevisions;
-                    } // otherwise fall-back to the default behavior
-                } 
-                
-                if (parentRevisions == null) {
-                    parentRevision = matrixRun.getParentBuild().getAction(MercurialTagAction.class);
-                }
-            } else {
-                parentRevision = matrixRun.getParentBuild().getAction(MercurialTagAction.class);
-            }
+            MercurialTagAction parentRevision = matrixRun.getParentBuild().getAction(MercurialTagAction.class);
 
             if (parentRevision != null && parentRevision.getId() != null) {
                 revToBuild = parentRevision.getId();

--- a/src/test/java/hudson/plugins/mercurial/MatrixProjectTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MatrixProjectTest.java
@@ -4,9 +4,7 @@ import hudson.Launcher;
 import hudson.Proc;
 import hudson.matrix.*;
 import hudson.model.*;
-import hudson.scm.SCM;
 import org.jvnet.hudson.test.FakeLauncher;
-import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.PretendSlave;
 import org.jvnet.hudson.test.TestBuilder;
@@ -17,7 +15,6 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.jenkinsci.plugins.multiplescms.MultiSCM;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,7 +28,6 @@ public class MatrixProjectTest {
     @Rule public TemporaryFolder tmp = new TemporaryFolder();
     @Rule public TemporaryFolder tmp2 = new TemporaryFolder();
     private File repo;
-    private File repo2;
     private MatrixProject matrixProject;
 
     @Before public void setUp() throws Exception {
@@ -48,39 +44,11 @@ public class MatrixProjectTest {
         m.touchAndCommit(repo, "a");
     }
 
-    private void setUpMultiSCM() throws Exception {
-        repo2 = tmp.newFolder();
-
-        matrixProject.setScm(new MultiSCM(Arrays.<SCM>asList(
-                new MercurialSCM(null, repo2.getPath(), null, null, "r2", null, false),
-                new MercurialSCM(null, repo.getPath(), null, null, "r1", null, false))));
-
-        m.hg(repo2, "init");
-        m.touchAndCommit(repo2, "r2f1");
-    }
-
     @Test public void allRunsBuildSameRevisionOnClone() throws Exception {
         assertAllMatrixRunsBuildSameMercurialRevision();
     }
 
     @Test public void allRunsBuildSameRevisionOnUpdate() throws Exception {
-        //schedule an initial build, to test update behavior later in the test
-        j.assertBuildStatusSuccess(matrixProject.scheduleBuild2(0));
-        m.touchAndCommit(repo, "ab");
-
-        assertAllMatrixRunsBuildSameMercurialRevision();
-    }
-
-    @Issue("JENKINS-18237")
-    @Test public void multiSCMRunsBuildSameRevisionOnClone() throws Exception {
-        setUpMultiSCM();
-        assertAllMatrixRunsBuildSameMercurialRevision();
-    }
-
-    @Issue("JENKINS-18237")
-    @Test public void multiSCMRunsBuildSameRevisionOnUpdate() throws Exception {
-        setUpMultiSCM();
-
         //schedule an initial build, to test update behavior later in the test
         j.assertBuildStatusSuccess(matrixProject.scheduleBuild2(0));
         m.touchAndCommit(repo, "ab");

--- a/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
+++ b/src/test/java/hudson/plugins/mercurial/SCMTestBase.java
@@ -25,7 +25,6 @@ import hudson.scm.SCMRevisionState;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -38,7 +37,6 @@ import java.util.TreeSet;
 import javax.annotation.CheckForNull;
 import org.apache.commons.io.FileUtils;
 
-import org.jenkinsci.plugins.multiplescms.MultiSCM;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -529,29 +527,6 @@ public abstract class SCMTestBase {
         b = p.scheduleBuild2(0).get();
         assertChangeSetPaths(
                 Collections.singletonList(Collections.singleton("dir3/f1")), b);
-    }
-
-    @Issue("JENKINS-12162")
-    @Test public void changelogInMultiSCM() throws Exception {
-        FreeStyleProject p = j.createFreeStyleProject();
-        m.hg(repo, "init");
-        m.touchAndCommit(repo, "r1f1");
-        File repo2 = tmp.newFolder();
-        m.hg(repo2, "init");
-        m.touchAndCommit(repo2, "r2f1");
-        p.setScm(new MultiSCM(Arrays.<SCM>asList(
-                new MercurialSCM(hgInstallation(), repo.getPath(), null, null, "r1", null, false),
-                new MercurialSCM(hgInstallation(), repo2.getPath(), null, null, "r2", null, false))));
-        FreeStyleBuild b = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-        m.touchAndCommit(repo, "r1f2");
-        m.touchAndCommit(repo2, "r2f2");
-        assertTrue(m.pollSCMChanges(p).hasChanges());
-        b = j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
-        List<Set<String>> paths = new ArrayList<Set<String>>();
-        // TODO "r1/r1f2" etc. would be preferable; probably requires determineChanges to prepend subdir?
-        paths.add(Collections.singleton("r1f2"));
-        paths.add(Collections.singleton("r2f2"));
-        assertChangeSetPaths(paths, b);
     }
 
     @Test public void polling() throws Exception {


### PR DESCRIPTION
This plugin is deprecated—long superseded by Pipeline. The immediate impetus is test failures (locally, not in CI, and evidently flaky)

```
expected:<[[r1f2], [r2f2]]> but was:<[[r2f2], [r1f2]]>
    	at org.junit.Assert.fail(Assert.java:89)
    	at org.junit.Assert.failNotEquals(Assert.java:835)
    	at org.junit.Assert.assertEquals(Assert.java:120)
    	at hudson.plugins.mercurial.SCMTestBase.assertChangeSetPaths(SCMTestBase.java:692)
    	at hudson.plugins.mercurial.SCMTestBase.changelogInMultiSCM(SCMTestBase.java:554)
```
