### PR TITLE
Skip PipelineTest.modernHook if Hg is using Python 2

### DIFF
--- a/src/test/java/hudson/plugins/mercurial/PipelineTest.java
+++ b/src/test/java/hudson/plugins/mercurial/PipelineTest.java
@@ -238,7 +238,11 @@ public class PipelineTest {
         m.registerHook(sampleRepo);
         sampleRepo.child("Jenkinsfile").write("node {checkout scm; echo readFile('file').toUpperCase()}", null);
         sampleRepo.child("file").write("subsequent content", null);
-        m.hg(sampleRepo, "commit", "--message=tweaked");
+        try {
+            m.hg(sampleRepo, "commit", "--message=tweaked");
+        } catch (AssertionError x) {
+            throw new AssumptionViolatedException("probably using Python 2", x);
+        }
 
         // wait for the event to have completed processing
         SCMEvents.awaitAll(watermark, 5, TimeUnit.SECONDS);


### PR DESCRIPTION
Amends #167, which broke some CI environments such as https://github.com/jenkinsci/plugin-compat-tester/blob/bb4f15c859c18865854168542a28d903c41dcab9/Dockerfile
