### PR TITLE
No need to override `reuseForks`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.19</version>
+        <version>4.31</version>
         <relativePath />
     </parent>
     <artifactId>mercurial</artifactId>
@@ -20,7 +20,6 @@
         <jenkins.version>2.190.3</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
-        <reuseForks>false</reuseForks> <!-- long story -->
     </properties>
     
     <developers>


### PR DESCRIPTION
As of https://github.com/jenkinsci/plugin-pom/pull/453. Supersedes #182.