### PR TITLE
[JENKINS-65175] Revert `ini4j` upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # JENKINS-65175
+      - dependency-name: "org.ini4j:ini4j"

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.ini4j</groupId>
             <artifactId>ini4j</artifactId>
-            <version>0.5.4</version>
+            <version>0.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
[JENKINS-65175](https://issues.jenkins.io/browse/JENKINS-65175): reverts #157.

The cleaner fix would likely be that suggested in a duplicate [JENKINS-66997](https://issues.jenkins.io/browse/JENKINS-66997):

```diff
diff --git a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
index e11cd3b..9d8b37f 100755
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -813,6 +813,7 @@ public class MercurialSCM extends SCM implements Serializable {
                 if (hgrc.exists()) {
                     try (InputStream is = hgrc.read()) {
                         Ini hgrcIni = new Ini(is);
+                        hgrcIni.getConfig().setEscape(false);
                         hgrcIni.put("paths", "default", getSource(env));
                         try (OutputStream os = hgrc.write()) {
                             hgrcIni.store(os);
```

plus some other points where `ini4j` is used. However, I do not have a self-contained test case to guard against regression, so simply reverting to the last library version thought to be unproblematic seems safer.
