### PR TITLE
[JENKINS-68562] Fix Mercurial checkouts on the built-in node for Windows controllers

### DIFF
--- a/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
+++ b/src/test/java/hudson/plugins/mercurial/MercurialSCMTest.java
@@ -24,14 +24,17 @@
 
 package hudson.plugins.mercurial;
 
+import hudson.AbortException;
 import hudson.model.Action;
 import hudson.model.Actionable;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 
 import java.io.IOException;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class MercurialSCMTest {
 
@@ -70,6 +73,15 @@ public class MercurialSCMTest {
             @Override public String getSearchUrl() {return null;}
         }, actualEnvironment);
         assertEquals(EXPECTED_REPOSITORY_URL, actualEnvironment.get("MERCURIAL_REPOSITORY_URL"));
+    }
+
+    @Issue("JENKINS-68562")
+    @Test public void abortIfSourceIsLocal() throws IOException {
+        try {
+            new MercurialSCM("", "https://mercurialserver/testrepo", "", "", "", null, true).abortIfSourceLocal();
+        } catch (AbortException e) {
+            fail("https source URLs should always be valid");
+        }
     }
 
 }


### PR DESCRIPTION
Backports #212 to 2.16.x. CC @Pldi23 

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
