### PR TITLE
Limit the 'Triggered' HTTP headers in the answer to push notifications

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialStatus.java
@@ -45,6 +45,8 @@ public class MercurialStatus implements UnprotectedRootAction {
 
     public static final String URL_NAME = "mercurial";
 
+    private static final int MAX_REPORTED_PROJECTS = 10;
+
     public String getDisplayName() {
         return Messages.MercurialStatus_mercurial();
     }
@@ -205,7 +207,12 @@ public class MercurialStatus implements UnprotectedRootAction {
             public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
                 rsp.setStatus(SC_OK);
                 rsp.setContentType("text/plain");
-                for (Item p : projects) {
+                for (int i = 0; i < projects.size(); i++) {
+                    if (i == MAX_REPORTED_PROJECTS) {
+                        rsp.addHeader("Triggered", "<" + (projects.size() - i) + " more>");
+                        break;
+                    }
+                    Item p = projects.get(i);
                     if (p.hasPermission2(origAuth, Item.READ)) {
                         rsp.addHeader("Triggered", p.getAbsoluteUrl());
                     } else {


### PR DESCRIPTION
Hi,

When a push-notification is sent to Jenkins, this plugin returns the names of the triggered projects: a 'Triggered' HTTP header per triggered project. If there are many projects triggered this way, a big HTTP header is returned. This might result in issues on the server and/or client who can't always handle such big HTTP headers.

This pull request limits the number of returned headers to 10 (feel free to choose another number here). If there are more triggered projects, the last header will contain "<xxx more>' with xxx the number of triggered projects not being included as HTTP header.

This has been reported here: https://issues.jenkins.io/browse/JENKINS-38720 . Note : the Jenkins git plugin had the same issue (https://issues.jenkins.io/browse/JENKINS-46929), this pull-request is similar as the one the fixed the git-plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
