### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@ buildPlugin(
   useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 17],
+    [platform: 'linux',   jdk: '21', jenkins: '2.414'],
     // TODO add Windows containers once we get Windows 2016 agents and DockerRule can handle Windows containers
 ])


### PR DESCRIPTION
## Test with Java 21

We'd like to support Jenkins on Java 21 shortly after the Sep 19, 2023 release of Java 21.  Testing plugins with Java 21 is part of that effort.

### Testing done

Confirmed tests pass on Linux with Java 21

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
