### PR TITLE
Add head name property in MercurialSCM

### DIFF
--- a/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCM.java
@@ -151,6 +151,8 @@ public class MercurialSCM extends SCM implements Serializable {
     @Deprecated
     private String branch;
 
+    private String headName = "default";
+
     /** Slash-separated subdirectory of the workspace in which the repository will be kept; null for top level. */
     private String subdir;
 
@@ -298,6 +300,14 @@ public class MercurialSCM extends SCM implements Serializable {
 
     @DataBoundSetter public final void setRevision(@NonNull String revision) {
         this.revision = Util.fixEmpty(revision) == null ? "default" : revision;
+    }
+
+    public @NonNull String getHeadName() {
+        return headName;
+    }
+
+    @DataBoundSetter public final void setHeadName(@NonNull String headName) {
+        this.headName = Util.fixEmpty(headName) == null ? "default" : headName;
     }
 
     @Deprecated

--- a/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
+++ b/src/main/java/hudson/plugins/mercurial/MercurialSCMBuilder.java
@@ -115,10 +115,13 @@ public class MercurialSCMBuilder<B extends MercurialSCMBuilder<B>> extends SCMBu
         MercurialSCM result = new MercurialSCM(source());
         if (revision instanceof MercurialSCMSource.MercurialRevision) {
             result.setRevisionType(MercurialSCM.RevisionType.CHANGESET);
-            result.setRevision(((MercurialSCMSource.MercurialRevision) revision).getHash());
+            MercurialSCMSource.MercurialRevision mercurialRevision = (MercurialSCMSource.MercurialRevision) revision;
+            result.setRevision(mercurialRevision.getHash());
+            result.setHeadName(mercurialRevision.getHead().getName());
         } else {
             result.setRevisionType(MercurialSCM.RevisionType.BRANCH);
             result.setRevision(head().getName());
+            result.setHeadName(head().getName());
         }
         result.setBrowser(browser());
         result.setClean(clean());


### PR DESCRIPTION
If use `resolveScm` in usual pipeline you cannot get branch name - `getRevision` return hash althought `resolveScm` print and branch name too. I use neutral name `headName` because we can search by tags too. Feature does not require specific tests - it just place data into `MercurialSCM` class.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
